### PR TITLE
Update Default options in verify

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ verify.TdxVerify(myAttestation, verify.Options())
 
 #### `Options` type
 
-This type contains four fields:
+This type contains five fields:
 
 *   `GetCollateral bool`: if true, then `TdxVerify` will download the collateral
     from Intel PCS API service and check against collateral obtained.
@@ -90,6 +90,8 @@ This type contains four fields:
     The `HTTPSGetter` interface consists of a single method `Get(url string)
     (map[string][]string, []byte, error)` that should return the headers and body
     of the HTTPS response.
+*   `Now time.Time`: if `nil`, uses `time.Now()`. It is the time at which to verify
+    the validity of certificates and collaterals
 *   `TrustedRoots *x509.CertPool`: if `nil`, uses the library's embedded
     certificate.
     Certificate chain verification is performed using trusted roots.

--- a/verify/verify.go
+++ b/verify/verify.go
@@ -735,7 +735,7 @@ func verifyPCKCertificationChain(options *Options) error {
 		return fmt.Errorf("unable to validate PCK leaf certificate: %v", err)
 	}
 
-	if _, err := pckCert.Verify(x509Options(options.TrustedRoots, intermediateCert, options)); err != nil {
+	if _, err := pckCert.Verify(x509Options(options.TrustedRoots, intermediateCert, options.Now)); err != nil {
 		return fmt.Errorf("error verifying PCK Certificate: %v (%v)", err, rootCert.IsCA)
 	}
 
@@ -768,7 +768,7 @@ func verifyPCKCertificationChain(options *Options) error {
 	return checkCertificateExpiration(chain, options)
 }
 
-func x509Options(trustedRoots *x509.CertPool, intermediateCert *x509.Certificate, options *Options) x509.VerifyOptions {
+func x509Options(trustedRoots *x509.CertPool, intermediateCert *x509.Certificate, now time.Time) x509.VerifyOptions {
 	if trustedRoots == nil {
 		logger.Warning("Using embedded Intel certificate for TDX attestation root of trust")
 		trustedRoots = x509.NewCertPool()
@@ -780,7 +780,7 @@ func x509Options(trustedRoots *x509.CertPool, intermediateCert *x509.Certificate
 		intermediates.AddCert(intermediateCert)
 	}
 
-	return x509.VerifyOptions{Roots: trustedRoots, Intermediates: intermediates, CurrentTime: options.Now}
+	return x509.VerifyOptions{Roots: trustedRoots, Intermediates: intermediates, CurrentTime: now}
 }
 
 func verifyHash256(quote *pb.QuoteV4) error {
@@ -1002,7 +1002,7 @@ func verifyResponse(signingPhrase string, rootCertificate *x509.Certificate, sig
 	if err := validateCertificate(signingCertificate, rootCertificate, signingPhrase); err != nil {
 		return fmt.Errorf("unable to validate signing certificate in the issuer chain: %v", err)
 	}
-	if _, err := signingCertificate.Verify(x509Options(options.TrustedRoots, nil, options)); err != nil {
+	if _, err := signingCertificate.Verify(x509Options(options.TrustedRoots, nil, options.Now)); err != nil {
 		return fmt.Errorf("unable to verify signing certificate: %v", err)
 	}
 

--- a/verify/verify_test.go
+++ b/verify/verify_test.go
@@ -134,7 +134,7 @@ func TestVerifyPckLeafCertificate(t *testing.T) {
 	}
 	pckLeafCert := pckChain.PCKCertificate
 	opts := &Options{CheckRevocations: false, GetCollateral: false, TrustedRoots: nil, chain: pckChain}
-	chains, err := pckLeafCert.Verify(x509Options(opts.TrustedRoots, pckChain.IntermediateCertificate, opts))
+	chains, err := pckLeafCert.Verify(x509Options(opts.TrustedRoots, pckChain.IntermediateCertificate, opts.Now))
 
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Add Now in options interface of verify to check against validity of certificates and collaterals.