### PR TITLE
Add a GoReleaser release action

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,6 +10,8 @@ builds:
     id: "attest"
     main: ./tools/attest/attest.go
     binary: attest
+  - env:
+      - CGO_ENABLED=0
     goos:
       - linux
 #      - windows


### PR DESCRIPTION
This will build the tool CLI binaries and package them on release. For folks not writing Go libraries and just want the tools, this should make using them easier.

This of course isn't the best means of distribution since there is no Google signature of the releases, and no provenance attestation, but it can at least be confirmed through a GitHub authenticated channel.