### PR TITLE
Fix Get Report ioctl

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -83,6 +83,8 @@ func GetRawQuote(d Device, reportData [64]byte) ([]uint8, uint32, error) {
 			return nil, 0, fmt.Errorf("the device driver return busy")
 		} else if labi.GetQuoteServiceUnavailable == tdxHdr.Status {
 			return nil, 0, fmt.Errorf("request feature is not supported")
+		} else if tdxHdr.OutLen > labi.ReqBufSize {
+			return nil, 0, fmt.Errorf("invalid Quote size: %v. It must be less than: %v", tdxHdr.OutLen, labi.ReqBufSize)
 		} else {
 			return nil, 0, fmt.Errorf("unexpected error: %v", tdxHdr.Status)
 		}

--- a/client/client.go
+++ b/client/client.go
@@ -66,7 +66,7 @@ func GetRawQuote(d Device, reportData [64]byte) ([]uint8, uint32, error) {
 		InLen:   labi.TdReportSize,
 		OutLen:  0,
 	}
-	copy(tdxHdr.Data[:], tdReport[:])
+	copy(tdxHdr.Data[:], tdReport[:labi.TdReportSize])
 	tdxReq := labi.TdxQuoteReq{
 		Buffer: tdxHdr,
 		Length: labi.ReqBufSize,
@@ -83,8 +83,8 @@ func GetRawQuote(d Device, reportData [64]byte) ([]uint8, uint32, error) {
 			return nil, 0, fmt.Errorf("the device driver return busy")
 		} else if labi.GetQuoteServiceUnavailable == tdxHdr.Status {
 			return nil, 0, fmt.Errorf("request feature is not supported")
-		} else if tdxHdr.OutLen > labi.ReqBufSize {
-			return nil, 0, fmt.Errorf("invalid Quote size: %v. It must be less than: %v", tdxHdr.OutLen, labi.ReqBufSize)
+		} else if tdxHdr.OutLen == 0 || tdxHdr.OutLen > labi.ReqBufSize {
+			return nil, 0, fmt.Errorf("invalid Quote size: %v. It must be > 0 and < : %v", tdxHdr.OutLen, labi.ReqBufSize)
 		} else {
 			return nil, 0, fmt.Errorf("unexpected error: %v", tdxHdr.Status)
 		}

--- a/client/client.go
+++ b/client/client.go
@@ -84,7 +84,7 @@ func GetRawQuote(d Device, reportData [64]byte) ([]uint8, uint32, error) {
 		} else if labi.GetQuoteServiceUnavailable == tdxHdr.Status {
 			return nil, 0, fmt.Errorf("request feature is not supported")
 		} else if tdxHdr.OutLen == 0 || tdxHdr.OutLen > labi.ReqBufSize {
-			return nil, 0, fmt.Errorf("invalid Quote size: %v. It must be > 0 and < : %v", tdxHdr.OutLen, labi.ReqBufSize)
+			return nil, 0, fmt.Errorf("invalid Quote size: %v. It must be > 0 and <= : %v", tdxHdr.OutLen, labi.ReqBufSize)
 		} else {
 			return nil, 0, fmt.Errorf("unexpected error: %v", tdxHdr.Status)
 		}

--- a/client/client_linux.go
+++ b/client/client_linux.go
@@ -20,9 +20,10 @@ package client
 import (
 	"fmt"
 
+	"unsafe"
+
 	labi "github.com/google/go-tdx-guest/client/linuxabi"
 	"golang.org/x/sys/unix"
-	"unsafe"
 )
 
 // defaultTdxGuestDevicePath is the platform's usual device path to the TDX guest.

--- a/client/client_linux.go
+++ b/client/client_linux.go
@@ -20,9 +20,9 @@ package client
 import (
 	"fmt"
 
-	"unsafe"
 	labi "github.com/google/go-tdx-guest/client/linuxabi"
 	"golang.org/x/sys/unix"
+	"unsafe"
 )
 
 // defaultTdxGuestDevicePath is the platform's usual device path to the TDX guest.
@@ -88,7 +88,7 @@ func (d *LinuxDevice) Ioctl(command uintptr, req any) (uintptr, error) {
 		}
 		return result, nil
 	case *labi.TdxReportReq:
-		result, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(d.fd), command, uintptr(unsafe.Pointer(req.(*labi.TdxReportReq)))) 
+		result, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(d.fd), command, uintptr(unsafe.Pointer(req.(*labi.TdxReportReq))))
 		if errno != 0 {
 			return 0, errno
 		}

--- a/client/client_linux.go
+++ b/client/client_linux.go
@@ -20,12 +20,13 @@ package client
 import (
 	"fmt"
 
+	"unsafe"
 	labi "github.com/google/go-tdx-guest/client/linuxabi"
 	"golang.org/x/sys/unix"
 )
 
 // defaultTdxGuestDevicePath is the platform's usual device path to the TDX guest.
-const defaultTdxGuestDevicePath = "/dev/tdx-guest"
+const defaultTdxGuestDevicePath = "/dev/tdx_guest"
 
 // LinuxDevice implements the Device interface with Linux ioctls.
 type LinuxDevice struct {
@@ -87,9 +88,7 @@ func (d *LinuxDevice) Ioctl(command uintptr, req any) (uintptr, error) {
 		}
 		return result, nil
 	case *labi.TdxReportReq:
-		abi := sreq.ABI()
-		result, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(d.fd), command, uintptr(abi.Pointer()))
-		abi.Finish(sreq)
+		result, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(d.fd), command, uintptr(unsafe.Pointer(req.(*labi.TdxReportReq)))) 
 		if errno != 0 {
 			return 0, errno
 		}

--- a/client/linuxabi/linux_abi.go
+++ b/client/linuxabi/linux_abi.go
@@ -34,15 +34,12 @@ const (
 	iocRead      = 2
 	// Linux /dev/tdx-guest ioctl interface
 	iocTypeTdxGuestReq = 'T'
-	iocTdxWithoutNr    = ((iocWrite | iocRead) << iocDirshift) |
-		(iocTypeTdxGuestReq << iocTypeshift) |
-		(64 << iocSizeshift)
-	// IocTdxGetReport is the ioctl command for getting an attestation report
-	IocTdxGetReport = iocTdxWithoutNr | (0x1 << iocNrshift)
-	// IocTdxGetQuote is the ioctl command for getting an attestation quote
-	IocTdxGetQuote = ((iocRead) << iocDirshift) |
-		(iocTypeTdxGuestReq << iocTypeshift) | (0x2 << iocNrshift) |
-		(64 << iocSizeshift)
+	iocTdxWithoutNrWithoutSize    = ((iocWrite | iocRead) << iocDirshift) |
+		(iocTypeTdxGuestReq << iocTypeshift)
+	// IocTdxGetReport is the ioctl command for getting an attestation report.
+	IocTdxGetReport = iocTdxWithoutNrWithoutSize | (unsafe.Sizeof(TdxReportReq{}) << iocSizeshift) | (0x1 << iocNrshift)
+	// IocTdxGetQuote is the ioctl command for getting an attestation quote.
+	IocTdxGetQuote = iocTdxWithoutNrWithoutSize | (unsafe.Sizeof(TdxQuoteReqABI{}) << iocSizeshift) | (0x2 << iocNrshift)
 	// TdReportDataSize is a constant for TDX ReportData size
 	TdReportDataSize = 64
 	// TdReportSize is a constant for TDX Report size

--- a/client/linuxabi/linux_abi.go
+++ b/client/linuxabi/linux_abi.go
@@ -33,8 +33,8 @@ const (
 	iocWrite     = 1
 	iocRead      = 2
 	// Linux /dev/tdx-guest ioctl interface
-	iocTypeTdxGuestReq = 'T'
-	iocTdxWithoutNrWithoutSize    = ((iocWrite | iocRead) << iocDirshift) |
+	iocTypeTdxGuestReq         = 'T'
+	iocTdxWithoutNrWithoutSize = ((iocWrite | iocRead) << iocDirshift) |
 		(iocTypeTdxGuestReq << iocTypeshift)
 	// IocTdxGetReport is the ioctl command for getting an attestation report.
 	IocTdxGetReport = iocTdxWithoutNrWithoutSize | (unsafe.Sizeof(TdxReportReq{}) << iocSizeshift) | (0x1 << iocNrshift)

--- a/client/linuxabi/linux_abi.go
+++ b/client/linuxabi/linux_abi.go
@@ -54,20 +54,6 @@ const (
 	GetQuoteReq = 0
 	// GetQuoteResp is a constant for report response
 	GetQuoteResp = 1
-	// MsgLibMajorVer is a constant for major version for header
-	MsgLibMajorVer = 1
-	// MsgLibMinorVer is a constant for minor version for header
-	MsgLibMinorVer = 0
-	// GetQuotesReqSize is a constant for Quote Request Msg
-	GetQuotesReqSize = 24
-	// GetQuoteRespSize is a constant for Quote Response Msg
-	GetQuoteRespSize = 24
-	// TdxQuoteHdrSize is a constant for Quote Header size
-	TdxQuoteHdrSize = 24
-	// TdQuoteBufSize is a constant denotes buffer size quote request
-	TdQuoteBufSize = ReqBufSize - GetQuotesReqSize
-	// TdIDQuoteSize is a constant denotes maximum size of array containing Quote
-	TdIDQuoteSize = TdQuoteBufSize - HeaderSize - TdxQuoteHdrSize
 )
 
 // EsResult is the status code type for Linux's GHCB communication results.
@@ -119,14 +105,6 @@ type SerializedGetQuoteReq struct {
 	ReportIDList [TdReportSize]uint8 // report followed by id list - [TODO revisit if attestation key ID is included]
 }
 
-// SerializedGetQuoteResp is used to serialized the response message.
-type SerializedGetQuoteResp struct {
-	Header         MsgHeader            // header.type = GET_QUOTE_RESP
-	SelectedIDSize uint32               // can be 0 in case only one id is sent in request
-	QuoteSize      uint32               // length of quote_data, in byte
-	IDQuote        [TdIDQuoteSize]uint8 // selected id followed by quote -[TODO revisit if attestation key ID is included]
-}
-
 // TdxQuoteHdr is Linux's tdx-guest ABI for quote header
 type TdxQuoteHdr struct {
 	/* Quote version, filled by TD */
@@ -138,7 +116,7 @@ type TdxQuoteHdr struct {
 	/* Length of Quote, filled by VMM */
 	OutLen uint32
 	/* Actual Quote data or TDREPORT on input */
-	Data [TdQuoteBufSize]byte
+	Data [ReqBufSize]byte
 }
 
 // ABI returns the object itself.

--- a/client/linuxabi/linux_abi.go
+++ b/client/linuxabi/linux_abi.go
@@ -93,75 +93,13 @@ const (
 	TdxAttestErrorUnexpected = 0x0001
 )
 
-// TdxReportDataABI is Linux's tdx-guest abi for ReportData
-type TdxReportDataABI struct {
-	// Data is the reportData of 64 bytes
-	Data [TdReportDataSize]uint8
-}
-
-// ABI returns the object itself.
-func (r *TdxReportDataABI) ABI() BinaryConversion { return r }
-
-// Pointer returns a pointer to the object itself.
-func (r *TdxReportDataABI) Pointer() unsafe.Pointer { return unsafe.Pointer(r) }
-
-// Finish is a no-op.
-func (r *TdxReportDataABI) Finish(BinaryConvertible) error {
-	return nil
-}
-
-// TdxReportABI is Linux's tdx-guest abi for report response
-type TdxReportABI struct {
-	// Data is the report response data
-	Data [TdReportSize]uint8
-}
-
-// ABI returns the object itself.
-func (r *TdxReportABI) ABI() BinaryConversion { return r }
-
-// Pointer returns a pointer to the object itself.
-func (r *TdxReportABI) Pointer() unsafe.Pointer { return unsafe.Pointer(r) }
-
-// Finish is a no-op.
-func (r *TdxReportABI) Finish(BinaryConvertible) error {
-	return nil
-}
-
-// TdxReportReqABI is Linux's tdx-guest ABI for TDX Report
-type TdxReportReqABI struct {
-	/* Report data of 64 bytes */
-	ReportData unsafe.Pointer
-	/* Actual TD Report Data */
-	TdReport unsafe.Pointer
-}
-
 // TdxReportReq is Linux's tdx-guest ABI for TDX Report. The
 // types here enhance runtime safety when using Ioctl as an interface.
 type TdxReportReq struct {
 	/* Report data of 64 bytes */
-	ReportData [TdReportDataSize]uint8
+	ReportData [TdReportDataSize]byte
 	/* Actual TD Report Data */
-	TdReport [TdReportSize]uint8
-}
-
-// ABI returns the object itself.
-func (r *TdxReportReq) ABI() BinaryConversion {
-	return &TdxReportReqABI{
-		ReportData: unsafe.Pointer(&r.ReportData[0]),
-		TdReport:   unsafe.Pointer(&r.TdReport[0]),
-	}
-}
-
-// Pointer returns a pointer to the object itself.
-func (r *TdxReportReqABI) Pointer() unsafe.Pointer { return unsafe.Pointer(r) }
-
-// Finish writes back the changed value.
-func (r *TdxReportReqABI) Finish(b BinaryConvertible) error {
-	_, ok := b.(*TdxReportReq)
-	if !ok {
-		return fmt.Errorf("argument is %v. Expects a *TdxReportReq", reflect.TypeOf(b))
-	}
-	return nil
+	TdReport [TdReportSize]byte
 }
 
 // MsgHeader is used to add header field to serialized request and response message.

--- a/testing/mocks.go
+++ b/testing/mocks.go
@@ -83,7 +83,7 @@ func (d *Device) getReport(req *labi.TdxReportReq) (uintptr, error) {
 
 func (d *Device) getQuote(req *labi.TdxQuoteHdr) (uintptr, error) {
 	var report [labi.TdReportSize]byte
-	copy(report[:], req.Data[:])
+	copy(report[:], req.Data[:labi.TdReportSize])
 	quoteRespI, ok := d.quoteResponse[report]
 	if !ok {
 		return 0, fmt.Errorf("test error: no response for %v", report)

--- a/testing/mocks.go
+++ b/testing/mocks.go
@@ -16,8 +16,6 @@
 package testing
 
 import (
-	"bytes"
-	"encoding/binary"
 	"fmt"
 	"strings"
 
@@ -26,13 +24,13 @@ import (
 
 // GetReportResponse represents a mocked response to a command request.
 type GetReportResponse struct {
-	Resp     labi.TdxReportABI
+	Resp     labi.TdxReportReq
 	EsResult labi.EsResult
 }
 
 // GetQuoteResponse represents a mocked response to a command request.
 type GetQuoteResponse struct {
-	Resp     labi.SerializedGetQuoteResp
+	Resp     labi.TdxQuoteHdr
 	EsResult labi.EsResult
 }
 
@@ -79,13 +77,13 @@ func (d *Device) getReport(req *labi.TdxReportReq) (uintptr, error) {
 		return 0, fmt.Errorf("test error: incorrect response for %v", tdReportRespI)
 	}
 	esResult := uintptr(tdReportResp.EsResult)
-	req.TdReport = tdReportResp.Resp.Data
+	req.TdReport = tdReportResp.Resp.TdReport
 	return esResult, nil
 }
 
 func (d *Device) getQuote(req *labi.TdxQuoteHdr) (uintptr, error) {
 	var report [labi.TdReportSize]byte
-	copy(report[:], req.Data[labi.GetQuotesReqSize+labi.HeaderSize:])
+	copy(report[:], req.Data[:])
 	quoteRespI, ok := d.quoteResponse[report]
 	if !ok {
 		return 0, fmt.Errorf("test error: no response for %v", report)
@@ -96,19 +94,8 @@ func (d *Device) getQuote(req *labi.TdxQuoteHdr) (uintptr, error) {
 		return 0, fmt.Errorf("test error: incorrect response for %v", quoteRespI)
 	}
 	esResult := uintptr(quoteResp.EsResult)
-
-	msgSize := uint32(quoteResp.Resp.Header.Size)
-	respSize := new(bytes.Buffer)
-	if err := binary.Write(respSize, binary.LittleEndian, msgSize); err != nil {
-		return 0, err
-	}
-	resp := new(bytes.Buffer)
-	if err := binary.Write(resp, binary.LittleEndian, quoteResp.Resp); err != nil {
-		return 0, err
-	}
-	data := append(respSize.Bytes(), resp.Bytes()...)
-	req.OutLen = quoteResp.Resp.QuoteSize + labi.HeaderSize + labi.GetQuoteRespSize
-	copy(req.Data[:], data[:])
+	copy(req.Data[:], quoteResp.Resp.Data[:])
+	req.OutLen = quoteResp.Resp.OutLen
 	return esResult, nil
 }
 

--- a/testing/test_cases.go
+++ b/testing/test_cases.go
@@ -109,25 +109,18 @@ func TcDevice(tcs []TestCase) (*Device, error) {
 	quoteResponses := map[[labi.TdReportSize]byte]any{}
 	for _, tc := range tcs {
 		reportResponses[tc.Input] = &GetReportResponse{
-			Resp: labi.TdxReportABI{
-				Data: tc.Report,
+			Resp: labi.TdxReportReq{
+				TdReport: tc.Report,
 			},
 			EsResult: tc.EsResult,
 		}
-		var idQuote [labi.TdIDQuoteSize]byte
+		var idQuote [labi.ReqBufSize]byte
 		copy(idQuote[:], tc.Quote)
 		quoteResponses[tc.Report] = &GetQuoteResponse{
-			Resp: labi.SerializedGetQuoteResp{
-				Header: labi.MsgHeader{
-					MajorVersion: labi.MsgLibMajorVer,
-					MinorVersion: labi.MsgLibMinorVer,
-					MsgType:      labi.GetQuoteResp,
-					Size:         4998,
-					ErrorCode:    0,
-				},
-				QuoteSize:      4974,
-				SelectedIDSize: 0,
-				IDQuote:        idQuote,
+			Resp: labi.TdxQuoteHdr{
+				Status: labi.GetQuoteSuccess,
+				OutLen: uint32(len(tc.Quote)),
+				Data:   idQuote,
 			},
 			EsResult: tc.EsResult,
 		}


### PR DESCRIPTION
Fixing Get Report IOCTL

This includes:
- Fix for ioctl command formation (for GET REPORT and GET QUOTE)
- Fixing ioctl implementation in client_linux for GET REPORT
- Fixing device path to '/dev/tdx_guest'
- Modifications required for GET QUOTE as per latest changes/spec.

Testing:
Verified locally using a mock `tdx_guest` module.
Also verified on a VM with appropriate host and guest images.