### PR TITLE
Rename TdxVerify function to TdxAttestation in verify package.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ and the requirements for certificate well-formedness come from the
 The presence of the PCK Certificate Chain within the input attestation quote is
 expected.
 
-### `func TdxVerify(quote *pb.QuoteV4, options *Options) error`
+### `func TdxAttestation(quote *pb.QuoteV4, options *Options) error`
 
 This function verifies that the attestation has a valid signature and
 certificate chain. It provides an optional verification against the collateral
@@ -73,23 +73,23 @@ documentation.
 Example expected invocation:
 
 ```
-verify.TdxVerify(myAttestation, verify.Options())
+verify.TdxAttestation(myAttestation, verify.Options())
 ```
 
 #### `Options` type
 
 This type contains five fields:
 
-*   `GetCollateral bool`: if true, then `TdxVerify` will download the collateral
+*   `GetCollateral bool`: if true, then `TdxAttestation` will download the collateral
     from Intel PCS API service and check against collateral obtained.
     Must be `true` if `CheckRevocations` is true.
-*   `CheckRevocations bool`: if true, then `TdxVerify` will download the
+*   `CheckRevocations bool`: if true, then `TdxAttestation` will download the
     certificate revocation list (CRL) from Intel PCS API service and check for
     revocations.
 *   `Getter HTTPSGetter`: if `nil`, uses `DefaultHTTPSGetter()`.
     The `HTTPSGetter` interface consists of a single method `Get(url string)
     (map[string][]string, []byte, error)` that should return the headers and body
-    of the HTTPS response.
+    of the HTssTPS response.
 *   `Now time.Time`: if `nil`, uses `time.Now()`. It is the time at which to verify
     the validity of certificates and collaterals.
 *   `TrustedRoots *x509.CertPool`: if `nil`, uses the library's embedded

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ This type contains five fields:
 *   `Getter HTTPSGetter`: if `nil`, uses `DefaultHTTPSGetter()`.
     The `HTTPSGetter` interface consists of a single method `Get(url string)
     (map[string][]string, []byte, error)` that should return the headers and body
-    of the HTssTPS response.
+    of the HTTPS response.
 *   `Now time.Time`: if `nil`, uses `time.Now()`. It is the time at which to verify
     the validity of certificates and collaterals.
 *   `TrustedRoots *x509.CertPool`: if `nil`, uses the library's embedded

--- a/tools/check/check.go
+++ b/tools/check/check.go
@@ -155,7 +155,7 @@ func main() {
 		TrustedRoots: nil,
 	}
 
-	if err := verify.TdxVerify(quote, &verifyOpts); err != nil {
+	if err := verify.TdxAttestation(quote, &verifyOpts); err != nil {
 		// Make the exit code more helpful when there are network errors
 		// that affected the result.
 		exitCode := exitVerify

--- a/verify/verify.go
+++ b/verify/verify.go
@@ -1192,7 +1192,7 @@ func TdxAttestation(quote *pb.QuoteV4, options *Options) error {
 
 // RawTdxQuoteVerify verifies the raw bytes representation of an attestation quote
 //
-// Deprecated: Use RawTdxQuoteAttestation instead. This function is no longer recommended for use.
+// Deprecated: Use RawTdxAttestation instead. This function is no longer recommended for use.
 func RawTdxQuoteVerify(raw []byte, options *Options) error {
 	quote, err := abi.QuoteToProto(raw)
 	if err != nil {
@@ -1202,8 +1202,8 @@ func RawTdxQuoteVerify(raw []byte, options *Options) error {
 	return TdxVerify(quote, options)
 }
 
-// RawTdxQuoteAttestation verifies the raw bytes representation of an attestation quote
-func RawTdxQuoteAttestation(raw []byte, options *Options) error {
+// RawTdxAttestation verifies the raw bytes representation of an attestation quote
+func RawTdxAttestation(raw []byte, options *Options) error {
 	quote, err := abi.QuoteToProto(raw)
 	if err != nil {
 		return fmt.Errorf("could not convert raw bytes to QuoteV4: %v", err)

--- a/verify/verify.go
+++ b/verify/verify.go
@@ -1199,7 +1199,7 @@ func RawTdxQuoteVerify(raw []byte, options *Options) error {
 		return fmt.Errorf("could not convert raw bytes to QuoteV4: %v", err)
 	}
 
-	return TdxVerify(quote, options)
+	return TdxAttestation(quote, options)
 }
 
 // RawTdxAttestation verifies the raw bytes representation of an attestation quote

--- a/verify/verify.go
+++ b/verify/verify.go
@@ -1108,9 +1108,10 @@ func verifyEvidence(quote *pb.QuoteV4, options *Options) error {
 	return verifyQuote(quote, options)
 }
 
-// Deprecated: Use TdxAttestation insted. This function is no longer recommended for use.
 // TdxVerify verifies the protobuf representation of an attestation quote's signature based
 // on the quote's SignatureAlgo, provided the certificate chain is valid.
+//
+// Deprecated: Use TdxAttestation instead. This function is no longer recommended for use.
 func TdxVerify(quote *pb.QuoteV4, options *Options) error {
 	if options == nil {
 		return ErrOptionsNil

--- a/verify/verify.go
+++ b/verify/verify.go
@@ -1191,7 +1191,19 @@ func TdxAttestation(quote *pb.QuoteV4, options *Options) error {
 }
 
 // RawTdxQuoteVerify verifies the raw bytes representation of an attestation quote
+//
+// Deprecated: Use RawTdxQuoteAttestation instead. This function is no longer recommended for use.
 func RawTdxQuoteVerify(raw []byte, options *Options) error {
+	quote, err := abi.QuoteToProto(raw)
+	if err != nil {
+		return fmt.Errorf("could not convert raw bytes to QuoteV4: %v", err)
+	}
+
+	return TdxVerify(quote, options)
+}
+
+// RawTdxQuoteAttestation verifies the raw bytes representation of an attestation quote
+func RawTdxQuoteAttestation(raw []byte, options *Options) error {
 	quote, err := abi.QuoteToProto(raw)
 	if err != nil {
 		return fmt.Errorf("could not convert raw bytes to QuoteV4: %v", err)

--- a/verify/verify_test.go
+++ b/verify/verify_test.go
@@ -247,7 +247,7 @@ func TestNegativeValidateX509Certificate(t *testing.T) {
 
 func TestRawQuoteVerifyWithoutCollateral(t *testing.T) {
 	options := &Options{CheckRevocations: false, GetCollateral: false, Now: currentTime}
-	if err := RawTdxQuoteVerify(testdata.RawQuote, options); err != nil {
+	if err := RawTdxQuoteAttestation(testdata.RawQuote, options); err != nil {
 		t.Error(err)
 	}
 }
@@ -329,8 +329,8 @@ func TestNegativeVerification(t *testing.T) {
 	for _, tc := range tests {
 		copy(rawQuote, testdata.RawQuote)
 		rawQuote[tc.changeIndex] = tc.changeValue
-		if err := RawTdxQuoteVerify(rawQuote, options); err == nil || err.Error() != tc.wantErr {
-			t.Errorf("%s: RawTdxQuoteVerify() = %v. Want error %v", tc.name, err, tc.wantErr)
+		if err := RawTdxQuoteAttestation(rawQuote, options); err == nil || err.Error() != tc.wantErr {
+			t.Errorf("%s: RawTdxQuoteAttestation() = %v. Want error %v", tc.name, err, tc.wantErr)
 		}
 	}
 }
@@ -710,8 +710,8 @@ func TestNegativeRawQuoteVerifyWithCollateral(t *testing.T) {
 	wantErr := "PCS's reported TDX TCB info failed TCB status check: no matching TCB level found"
 	// Due to updated SVN values in the sample response, it will result in TCB status failure,
 	// when compared to the TD Quote Body's TeeTcbSvn value.
-	if err := RawTdxQuoteVerify(testdata.RawQuote, options); err == nil || err.Error() != wantErr {
-		t.Errorf("No matching TCB: RawTdxQuoteVerify() = %v. Want error %v", err, wantErr)
+	if err := RawTdxQuoteAttestation(testdata.RawQuote, options); err == nil || err.Error() != wantErr {
+		t.Errorf("No matching TCB: RawTdxQuoteAttestation() = %v. Want error %v", err, wantErr)
 	}
 }
 
@@ -719,7 +719,7 @@ func TestNegativeCheckRevocation(t *testing.T) {
 	getter := testcases.TestGetter
 	options := &Options{CheckRevocations: true, GetCollateral: false, Getter: getter}
 	wantErr := "unable to check for certificate revocation as GetCollateral parameter in the options is set to false"
-	if err := RawTdxQuoteVerify(testdata.RawQuote, options); err == nil || err.Error() != wantErr {
-		t.Errorf("Check Revocation Without GetCollateral: RawTdxQuoteVerify() = %v. Want error %v", err, wantErr)
+	if err := RawTdxQuoteAttestation(testdata.RawQuote, options); err == nil || err.Error() != wantErr {
+		t.Errorf("Check Revocation Without GetCollateral: RawTdxQuoteAttestation() = %v. Want error %v", err, wantErr)
 	}
 }

--- a/verify/verify_test.go
+++ b/verify/verify_test.go
@@ -247,7 +247,7 @@ func TestNegativeValidateX509Certificate(t *testing.T) {
 
 func TestRawQuoteVerifyWithoutCollateral(t *testing.T) {
 	options := &Options{CheckRevocations: false, GetCollateral: false, Now: currentTime}
-	if err := RawTdxQuoteAttestation(testdata.RawQuote, options); err != nil {
+	if err := RawTdxAttestation(testdata.RawQuote, options); err != nil {
 		t.Error(err)
 	}
 }
@@ -329,8 +329,8 @@ func TestNegativeVerification(t *testing.T) {
 	for _, tc := range tests {
 		copy(rawQuote, testdata.RawQuote)
 		rawQuote[tc.changeIndex] = tc.changeValue
-		if err := RawTdxQuoteAttestation(rawQuote, options); err == nil || err.Error() != tc.wantErr {
-			t.Errorf("%s: RawTdxQuoteAttestation() = %v. Want error %v", tc.name, err, tc.wantErr)
+		if err := RawTdxAttestation(rawQuote, options); err == nil || err.Error() != tc.wantErr {
+			t.Errorf("%s: RawTdxAttestation() = %v. Want error %v", tc.name, err, tc.wantErr)
 		}
 	}
 }
@@ -710,8 +710,8 @@ func TestNegativeRawQuoteVerifyWithCollateral(t *testing.T) {
 	wantErr := "PCS's reported TDX TCB info failed TCB status check: no matching TCB level found"
 	// Due to updated SVN values in the sample response, it will result in TCB status failure,
 	// when compared to the TD Quote Body's TeeTcbSvn value.
-	if err := RawTdxQuoteAttestation(testdata.RawQuote, options); err == nil || err.Error() != wantErr {
-		t.Errorf("No matching TCB: RawTdxQuoteAttestation() = %v. Want error %v", err, wantErr)
+	if err := RawTdxAttestation(testdata.RawQuote, options); err == nil || err.Error() != wantErr {
+		t.Errorf("No matching TCB: RawTdxAttestation() = %v. Want error %v", err, wantErr)
 	}
 }
 
@@ -719,7 +719,7 @@ func TestNegativeCheckRevocation(t *testing.T) {
 	getter := testcases.TestGetter
 	options := &Options{CheckRevocations: true, GetCollateral: false, Getter: getter}
 	wantErr := "unable to check for certificate revocation as GetCollateral parameter in the options is set to false"
-	if err := RawTdxQuoteAttestation(testdata.RawQuote, options); err == nil || err.Error() != wantErr {
-		t.Errorf("Check Revocation Without GetCollateral: RawTdxQuoteAttestation() = %v. Want error %v", err, wantErr)
+	if err := RawTdxAttestation(testdata.RawQuote, options); err == nil || err.Error() != wantErr {
+		t.Errorf("Check Revocation Without GetCollateral: RawTdxAttestation() = %v. Want error %v", err, wantErr)
 	}
 }


### PR DESCRIPTION
Deprecate TdxVerify and add TdxAttestation function in the verify package