### PR TITLE
Rename RawTdxQuoteValidate function name to RawTdxAttestation in validate package.

### DIFF
--- a/validate/validate.go
+++ b/validate/validate.go
@@ -268,7 +268,18 @@ func TdxAttestation(quote *pb.QuoteV4, options *Options) error {
 }
 
 // RawTdxQuoteValidate checks the raw bytes representation of an attestation quote.
+//
+// Deprecated: Use RawTdxAttestation instead. This function is no longer recommended for use.
 func RawTdxQuoteValidate(raw []byte, options *Options) error {
+	quote, err := abi.QuoteToProto(raw)
+	if err != nil {
+		return fmt.Errorf("could not convert raw bytes to QuoteV4: %v", err)
+	}
+	return TdxAttestation(quote, options)
+}
+
+// RawTdxAttestation checks the raw bytes representation of an attestation quote.
+func RawTdxAttestation(raw []byte, options *Options) error {
 	quote, err := abi.QuoteToProto(raw)
 	if err != nil {
 		return fmt.Errorf("could not convert raw bytes to QuoteV4: %v", err)


### PR DESCRIPTION
Deprecate RawTdxQuoteValidate and add RawTdxAttestation function in the validate package