### PR TITLE
Rename TdxAttestation to TdxQuote

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ and the requirements for certificate well-formedness come from the
 The presence of the PCK Certificate Chain within the input attestation quote is
 expected.
 
-### `func TdxAttestation(quote *pb.QuoteV4, options *Options) error`
+### `func TdxQuote(quote *pb.QuoteV4, options *Options) error`
 
 This function verifies that the attestation has a valid signature and
 certificate chain. It provides an optional verification against the collateral
@@ -73,17 +73,17 @@ documentation.
 Example expected invocation:
 
 ```
-verify.TdxAttestation(myAttestation, verify.Options())
+verify.TdxQuote(myAttestation, verify.Options())
 ```
 
 #### `Options` type
 
 This type contains five fields:
 
-*   `GetCollateral bool`: if true, then `TdxAttestation` will download the collateral
+*   `GetCollateral bool`: if true, then `TdxQuote` will download the collateral
     from Intel PCS API service and check against collateral obtained.
     Must be `true` if `CheckRevocations` is true.
-*   `CheckRevocations bool`: if true, then `TdxAttestation` will download the
+*   `CheckRevocations bool`: if true, then `TdxQuote` will download the
     certificate revocation list (CRL) from Intel PCS API service and check for
     revocations.
 *   `Getter HTTPSGetter`: if `nil`, uses `DefaultHTTPSGetter()`.

--- a/tools/check/check.go
+++ b/tools/check/check.go
@@ -155,7 +155,7 @@ func main() {
 		TrustedRoots: nil,
 	}
 
-	if err := verify.TdxAttestation(quote, &verifyOpts); err != nil {
+	if err := verify.TdxQuote(quote, &verifyOpts); err != nil {
 		// Make the exit code more helpful when there are network errors
 		// that affected the result.
 		exitCode := exitVerify

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -250,9 +250,9 @@ func validateTdAttributes(value []byte, fixed1, fixed0 uint64) error {
 	return nil
 }
 
-// TdxAttestation validates fields of the protobuf representation of an attestation Quote against
+// TdxQuote validates fields of the protobuf representation of an attestation Quote against
 // expectations. Does not check the attestation certificates or signature.
-func TdxAttestation(quote *pb.QuoteV4, options *Options) error {
+func TdxQuote(quote *pb.QuoteV4, options *Options) error {
 	if options == nil {
 		return vr.ErrOptionsNil
 	}
@@ -269,20 +269,20 @@ func TdxAttestation(quote *pb.QuoteV4, options *Options) error {
 
 // RawTdxQuoteValidate checks the raw bytes representation of an attestation quote.
 //
-// Deprecated: Use RawTdxAttestation instead. This function is no longer recommended for use.
+// Deprecated: Use RawTdxQuote instead. This function is no longer recommended for use.
 func RawTdxQuoteValidate(raw []byte, options *Options) error {
 	quote, err := abi.QuoteToProto(raw)
 	if err != nil {
 		return fmt.Errorf("could not convert raw bytes to QuoteV4: %v", err)
 	}
-	return TdxAttestation(quote, options)
+	return TdxQuote(quote, options)
 }
 
-// RawTdxAttestation checks the raw bytes representation of an attestation quote.
-func RawTdxAttestation(raw []byte, options *Options) error {
+// RawTdxQuote checks the raw bytes representation of an attestation quote.
+func RawTdxQuote(raw []byte, options *Options) error {
 	quote, err := abi.QuoteToProto(raw)
 	if err != nil {
 		return fmt.Errorf("could not convert raw bytes to QuoteV4: %v", err)
 	}
-	return TdxAttestation(quote, options)
+	return TdxQuote(quote, options)
 }

--- a/validate/validate_test.go
+++ b/validate/validate_test.go
@@ -32,8 +32,8 @@ func convert(a []byte, x byte) []byte {
 	return a
 }
 
-func TestTdxAttestation(t *testing.T) {
-	if err := TdxAttestation(nil, nil); err != vr.ErrOptionsNil {
+func TestTdxQuote(t *testing.T) {
+	if err := TdxQuote(nil, nil); err != vr.ErrOptionsNil {
 		t.Error(err)
 	}
 	qeSvn := uint16(0)
@@ -262,9 +262,9 @@ func TestTdxAttestation(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		if err := TdxAttestation(tc.quote, tc.opts); (err == nil && tc.wantErr != "") ||
+		if err := TdxQuote(tc.quote, tc.opts); (err == nil && tc.wantErr != "") ||
 			(err != nil && (tc.wantErr == "" || !strings.Contains(err.Error(), tc.wantErr))) {
-			t.Errorf("%s: TdxAttestation() errored unexpectedly. Got '%v', want '%s'", tc.name, err, tc.wantErr)
+			t.Errorf("%s: TdxQuote() errored unexpectedly. Got '%v', want '%s'", tc.name, err, tc.wantErr)
 		}
 	}
 }

--- a/verify/verify.go
+++ b/verify/verify.go
@@ -1111,7 +1111,7 @@ func verifyEvidence(quote *pb.QuoteV4, options *Options) error {
 // TdxVerify verifies the protobuf representation of an attestation quote's signature based
 // on the quote's SignatureAlgo, provided the certificate chain is valid.
 //
-// Deprecated: Use TdxAttestation instead. This function is no longer recommended for use.
+// Deprecated: Use TdxQuote instead. This function is no longer recommended for use.
 func TdxVerify(quote *pb.QuoteV4, options *Options) error {
 	if options == nil {
 		return ErrOptionsNil
@@ -1150,9 +1150,9 @@ func TdxVerify(quote *pb.QuoteV4, options *Options) error {
 	return verifyEvidence(quote, options)
 }
 
-// TdxAttestation verifies the protobuf representation of an attestation quote's signature based
+// TdxQuote verifies the protobuf representation of an attestation quote's signature based
 // on the quote's SignatureAlgo, provided the certificate chain is valid.
-func TdxAttestation(quote *pb.QuoteV4, options *Options) error {
+func TdxQuote(quote *pb.QuoteV4, options *Options) error {
 	if options == nil {
 		return ErrOptionsNil
 	}
@@ -1192,24 +1192,24 @@ func TdxAttestation(quote *pb.QuoteV4, options *Options) error {
 
 // RawTdxQuoteVerify verifies the raw bytes representation of an attestation quote
 //
-// Deprecated: Use RawTdxAttestation instead. This function is no longer recommended for use.
+// Deprecated: Use RawTdxQuote instead. This function is no longer recommended for use.
 func RawTdxQuoteVerify(raw []byte, options *Options) error {
 	quote, err := abi.QuoteToProto(raw)
 	if err != nil {
 		return fmt.Errorf("could not convert raw bytes to QuoteV4: %v", err)
 	}
 
-	return TdxAttestation(quote, options)
+	return TdxQuote(quote, options)
 }
 
-// RawTdxAttestation verifies the raw bytes representation of an attestation quote
-func RawTdxAttestation(raw []byte, options *Options) error {
+// RawTdxQuote verifies the raw bytes representation of an attestation quote
+func RawTdxQuote(raw []byte, options *Options) error {
 	quote, err := abi.QuoteToProto(raw)
 	if err != nil {
 		return fmt.Errorf("could not convert raw bytes to QuoteV4: %v", err)
 	}
 
-	return TdxAttestation(quote, options)
+	return TdxQuote(quote, options)
 }
 
 // Parse root certificates from the embedded trusted_root certificate file.

--- a/verify/verify_test.go
+++ b/verify/verify_test.go
@@ -247,7 +247,7 @@ func TestNegativeValidateX509Certificate(t *testing.T) {
 
 func TestRawQuoteVerifyWithoutCollateral(t *testing.T) {
 	options := &Options{CheckRevocations: false, GetCollateral: false, Now: currentTime}
-	if err := RawTdxAttestation(testdata.RawQuote, options); err != nil {
+	if err := RawTdxQuote(testdata.RawQuote, options); err != nil {
 		t.Error(err)
 	}
 }
@@ -329,8 +329,8 @@ func TestNegativeVerification(t *testing.T) {
 	for _, tc := range tests {
 		copy(rawQuote, testdata.RawQuote)
 		rawQuote[tc.changeIndex] = tc.changeValue
-		if err := RawTdxAttestation(rawQuote, options); err == nil || err.Error() != tc.wantErr {
-			t.Errorf("%s: RawTdxAttestation() = %v. Want error %v", tc.name, err, tc.wantErr)
+		if err := RawTdxQuote(rawQuote, options); err == nil || err.Error() != tc.wantErr {
+			t.Errorf("%s: RawTdxQuote() = %v. Want error %v", tc.name, err, tc.wantErr)
 		}
 	}
 }
@@ -710,8 +710,8 @@ func TestNegativeRawQuoteVerifyWithCollateral(t *testing.T) {
 	wantErr := "PCS's reported TDX TCB info failed TCB status check: no matching TCB level found"
 	// Due to updated SVN values in the sample response, it will result in TCB status failure,
 	// when compared to the TD Quote Body's TeeTcbSvn value.
-	if err := RawTdxAttestation(testdata.RawQuote, options); err == nil || err.Error() != wantErr {
-		t.Errorf("No matching TCB: RawTdxAttestation() = %v. Want error %v", err, wantErr)
+	if err := RawTdxQuote(testdata.RawQuote, options); err == nil || err.Error() != wantErr {
+		t.Errorf("No matching TCB: RawTdxQuote() = %v. Want error %v", err, wantErr)
 	}
 }
 
@@ -719,7 +719,7 @@ func TestNegativeCheckRevocation(t *testing.T) {
 	getter := testcases.TestGetter
 	options := &Options{CheckRevocations: true, GetCollateral: false, Getter: getter}
 	wantErr := "unable to check for certificate revocation as GetCollateral parameter in the options is set to false"
-	if err := RawTdxAttestation(testdata.RawQuote, options); err == nil || err.Error() != wantErr {
-		t.Errorf("Check Revocation Without GetCollateral: RawTdxAttestation() = %v. Want error %v", err, wantErr)
+	if err := RawTdxQuote(testdata.RawQuote, options); err == nil || err.Error() != wantErr {
+		t.Errorf("Check Revocation Without GetCollateral: RawTdxQuote() = %v. Want error %v", err, wantErr)
 	}
 }


### PR DESCRIPTION
TdxAttestation is now replaced with TdxQuote to make it standard for our library