### PR TITLE
Remove deprecated functions

### DIFF
--- a/validate/validate.go
+++ b/validate/validate.go
@@ -289,17 +289,6 @@ func TdxQuote(quote *pb.QuoteV4, options *Options) error {
 	)
 }
 
-// RawTdxQuoteValidate checks the raw bytes representation of an attestation quote.
-//
-// Deprecated: Use RawTdxQuote instead. This function is no longer recommended for use.
-func RawTdxQuoteValidate(raw []byte, options *Options) error {
-	quote, err := abi.QuoteToProto(raw)
-	if err != nil {
-		return fmt.Errorf("could not convert raw bytes to QuoteV4: %v", err)
-	}
-	return TdxQuote(quote, options)
-}
-
 // RawTdxQuote checks the raw bytes representation of an attestation quote.
 func RawTdxQuote(raw []byte, options *Options) error {
 	quote, err := abi.QuoteToProto(raw)

--- a/verify/verify.go
+++ b/verify/verify.go
@@ -1110,48 +1110,6 @@ func verifyEvidence(quote *pb.QuoteV4, options *Options) error {
 	return verifyQuote(quote, options)
 }
 
-// TdxVerify verifies the protobuf representation of an attestation quote's signature based
-// on the quote's SignatureAlgo, provided the certificate chain is valid.
-//
-// Deprecated: Use TdxQuote instead. This function is no longer recommended for use.
-func TdxVerify(quote *pb.QuoteV4, options *Options) error {
-	if options == nil {
-		return ErrOptionsNil
-	}
-
-	if err := abi.CheckQuoteV4(quote); err != nil {
-		return fmt.Errorf("QuoteV4 invalid: %v", err)
-	}
-
-	chain, err := extractChainFromQuote(quote)
-	if err != nil {
-		return err
-	}
-	exts, err := pcs.PckCertificateExtensions(chain.PCKCertificate)
-	if err != nil {
-		return fmt.Errorf("could not get PCK certificate extensions: %v", err)
-	}
-	var collateral *Collateral
-	if options.GetCollateral {
-
-		ca, err := extractCaFromPckCert(chain.PCKCertificate)
-		if err != nil {
-			return err
-		}
-		collateral, err = obtainCollateral(exts.FMSPC, ca, options)
-		if err != nil {
-			return err
-		}
-	}
-	options.collateral = collateral
-	options.pckCertExtensions = exts
-	options.chain = chain
-	if options.Now.IsZero() {
-		options.Now = time.Now()
-	}
-	return verifyEvidence(quote, options)
-}
-
 // TdxQuote verifies the protobuf representation of an attestation quote's signature based
 // on the quote's SignatureAlgo, provided the certificate chain is valid.
 func TdxQuote(quote *pb.QuoteV4, options *Options) error {
@@ -1190,18 +1148,6 @@ func TdxQuote(quote *pb.QuoteV4, options *Options) error {
 		options.Now = time.Now()
 	}
 	return verifyEvidence(quote, options)
-}
-
-// RawTdxQuoteVerify verifies the raw bytes representation of an attestation quote
-//
-// Deprecated: Use RawTdxQuote instead. This function is no longer recommended for use.
-func RawTdxQuoteVerify(raw []byte, options *Options) error {
-	quote, err := abi.QuoteToProto(raw)
-	if err != nil {
-		return fmt.Errorf("could not convert raw bytes to QuoteV4: %v", err)
-	}
-
-	return TdxQuote(quote, options)
 }
 
 // RawTdxQuote verifies the raw bytes representation of an attestation quote


### PR DESCRIPTION
Functions that have been marked as deprecated are being removed because they are no longer supported.