### PR TITLE
Add verbose logging to check CLI

### DIFF
--- a/tools/check/check.go
+++ b/tools/check/check.go
@@ -436,7 +436,7 @@ func main() {
 		die(err)
 	}
 	if err := validate.TdxQuote(quote, opts); err != nil {
-		dieWith(fmt.Errorf("error validating TDX Quote: %v", err), exitPolicy)
+		dieWith(fmt.Errorf("error validating the TDX Quote: %v", err), exitPolicy)
 	}
 	logger.V(1).Info("TDX Quote validated successfully")
 }

--- a/tools/check/check.go
+++ b/tools/check/check.go
@@ -366,10 +366,15 @@ func populateConfig() error {
 }
 
 func main() {
-	logger.Init("", *verbose, false, os.Stderr)
+	logger.Init("", false, false, os.Stderr)
 	flag.Parse()
 	cmdline.Parse("auto")
 
+	if *verbose {
+		logger.SetLevel(1)
+	}
+
+	logger.V(1).Info("Parsing input parameters")
 	if err := parseConfig(*configProto); err != nil {
 		die(err)
 	}
@@ -385,10 +390,13 @@ func main() {
 	if err != nil {
 		die(err)
 	}
+	logger.V(1).Info("Quote parsed successfully")
+
 	sopts, err := verify.RootOfTrustToOptions(config.RootOfTrust)
 	if err != nil {
 		die(err)
 	}
+	logger.V(1).Info("Input parameters parsed successfully")
 
 	var getter trust.HTTPSGetter
 	getter = &trust.SimpleHTTPSGetter{}
@@ -400,6 +408,8 @@ func main() {
 		MaxRetryDelay: *maxRetryDelay,
 		Getter:        getter,
 	}
+
+	logger.V(1).Info("Verifying the TDX quote from input")
 	if err := verify.TdxQuote(quote, sopts); err != nil {
 		// Make the exit code more helpful when there are network errors
 		// that affected the result.
@@ -422,6 +432,7 @@ func main() {
 		}
 		dieWith(fmt.Errorf("could not verify the quote: %v", err), exitCode)
 	}
+	logger.V(1).Info("Quote verified successfully")
 
 	opts, err := validate.PolicyToOptions(config.Policy)
 	if err != nil {
@@ -430,4 +441,5 @@ func main() {
 	if err := validate.TdxQuote(quote, opts); err != nil {
 		dieWith(fmt.Errorf("error validating quote: %v", err), exitPolicy)
 	}
+	logger.V(1).Info("Quote validated successfully")
 }

--- a/tools/check/check.go
+++ b/tools/check/check.go
@@ -67,7 +67,7 @@ var (
 			" overwrite the message's associated field. By default, the file will be unmarshalled as binary," +
 			" but if it ends in .textproto, it will be unmarshalled as prototext instead."))
 	quiet   = flag.Bool("quiet", false, "If true, writes nothing the stdout or stderr. Success is exit code 0, failure exit code 1.")
-	verbose = flag.Bool("verbose", false, "Enable verbose logging.")
+	verbose = flag.Int("verbosity", 0, "The output verbosity. Higher number means more verbose output")
 
 	qevendoridS    = flag.String("qe_vendor_id", "", "The expected QE_VENDOR_ID field as a hex string. Must encode 16 bytes. Unchecked if unset.")
 	qevendorid     = cmdline.Bytes("-qe_vendor_id", abi.QeVendorIDSize, qevendoridS)
@@ -369,10 +369,7 @@ func main() {
 	logger.Init("", false, false, os.Stderr)
 	flag.Parse()
 	cmdline.Parse("auto")
-
-	if *verbose {
-		logger.SetLevel(1)
-	}
+	logger.SetLevel(logger.Level(*verbose))
 
 	logger.V(1).Info("Parsing input parameters")
 	if err := parseConfig(*configProto); err != nil {

--- a/tools/check/check.go
+++ b/tools/check/check.go
@@ -117,7 +117,7 @@ var (
 func parseQuoteBytes(b []byte) (*pb.QuoteV4, error) {
 	quote, err := abi.QuoteToProto(b)
 	if err != nil {
-		return nil, fmt.Errorf("could not parse the quote from %q: %v", *infile, err)
+		return nil, fmt.Errorf("could not parse the TDX Quote from %q: %v", *infile, err)
 	}
 
 	return quote, nil
@@ -192,7 +192,7 @@ func readQuote() (*pb.QuoteV4, error) {
 
 func dieWith(err error, exitCode int) {
 	if !*quiet {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
+		fmt.Fprintf(os.Stderr, "FATAL: %v\n", err)
 	}
 	os.Exit(exitCode)
 }
@@ -366,7 +366,7 @@ func populateConfig() error {
 }
 
 func main() {
-	logger.Init("", false, false, os.Stderr)
+	logger.Init("", false, false, os.Stdout)
 	flag.Parse()
 	cmdline.Parse("auto")
 	logger.SetLevel(logger.Level(*verbose))
@@ -387,7 +387,7 @@ func main() {
 	if err != nil {
 		die(err)
 	}
-	logger.V(1).Info("Quote parsed successfully")
+	logger.V(1).Info("TDX Quote parsed successfully")
 
 	sopts, err := verify.RootOfTrustToOptions(config.RootOfTrust)
 	if err != nil {
@@ -406,7 +406,7 @@ func main() {
 		Getter:        getter,
 	}
 
-	logger.V(1).Info("Verifying the TDX quote from input")
+	logger.V(1).Info("Verifying the TDX Quote from input")
 	if err := verify.TdxQuote(quote, sopts); err != nil {
 		// Make the exit code more helpful when there are network errors
 		// that affected the result.
@@ -427,16 +427,16 @@ func main() {
 		if !clarify(err) {
 			clarify(errors.Unwrap(err))
 		}
-		dieWith(fmt.Errorf("could not verify the quote: %v", err), exitCode)
+		dieWith(fmt.Errorf("could not verify the TDX Quote: %v", err), exitCode)
 	}
-	logger.Info("Quote verified successfully")
+	logger.Info("TDX Quote verified successfully")
 
 	opts, err := validate.PolicyToOptions(config.Policy)
 	if err != nil {
 		die(err)
 	}
 	if err := validate.TdxQuote(quote, opts); err != nil {
-		dieWith(fmt.Errorf("error validating quote: %v", err), exitPolicy)
+		dieWith(fmt.Errorf("error validating TDX Quote: %v", err), exitPolicy)
 	}
-	logger.V(1).Info("Quote validated successfully")
+	logger.V(1).Info("TDX Quote validated successfully")
 }

--- a/tools/check/check.go
+++ b/tools/check/check.go
@@ -429,7 +429,7 @@ func main() {
 		}
 		dieWith(fmt.Errorf("could not verify the quote: %v", err), exitCode)
 	}
-	logger.V(1).Info("Quote verified successfully")
+	logger.Info("Quote verified successfully")
 
 	opts, err := validate.PolicyToOptions(config.Policy)
 	if err != nil {

--- a/verify/verify.go
+++ b/verify/verify.go
@@ -1202,4 +1202,7 @@ func RootOfTrustToOptions(rot *ccpb.RootOfTrust) (*Options, error) {
 func init() {
 	root, _ := pem.Decode(defaultRootCertByte)
 	trustedRootCertificate, _ = x509.ParseCertificate(root.Bytes)
+
+	// Initialize logger
+	logger.Init("", false, false, os.Stderr)
 }

--- a/verify/verify.go
+++ b/verify/verify.go
@@ -1204,5 +1204,5 @@ func init() {
 	trustedRootCertificate, _ = x509.ParseCertificate(root.Bytes)
 
 	// Initialize logger
-	logger.Init("", false, false, os.Stderr)
+	logger.Init("", false, false, os.Stdout)
 }


### PR DESCRIPTION
Basic logging has been added to the check CLI. More detailed information will be output to the logs when the verbosity flag is set to 1.