### PR TITLE
Integrate go-configfs-tsm library into go-tdx-guest to enable attestation quote fetch via ConfigFS

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -40,6 +40,7 @@ type QuoteProvider interface {
 	IsSupported() error
 	GetRawQuote(reportData [64]byte) ([]uint8, error)
 }
+
 // UseDefaultTdxGuestDevice returns true if tdxGuestPath=default.
 func UseDefaultTdxGuestDevice() bool {
 	return *tdxGuestPath == "default"
@@ -109,6 +110,7 @@ func GetQuote(d Device, reportData [64]byte) (*pb.QuoteV4, error) {
 	}
 	return convertRawQuoteToProto(quotebytes)
 }
+
 // GetRawQuoteViaProvider use QuoteProvider to fetch quote in byte array format.
 func GetRawQuoteViaProvider(qp QuoteProvider, reportData [64]byte) ([]uint8, error) {
 	if err := qp.IsSupported(); err == nil {
@@ -116,6 +118,7 @@ func GetRawQuoteViaProvider(qp QuoteProvider, reportData [64]byte) ([]uint8, err
 	}
 	return fallbackToDeviceForRawQuote(reportData)
 }
+
 // GetQuoteViaProvider use QuoteProvider to fetch attestation quote.
 func GetQuoteViaProvider(qp QuoteProvider, reportData [64]byte) (*pb.QuoteV4, error) {
 	bytes, err := GetRawQuoteViaProvider(qp, reportData)
@@ -124,6 +127,7 @@ func GetQuoteViaProvider(qp QuoteProvider, reportData [64]byte) (*pb.QuoteV4, er
 	}
 	return convertRawQuoteToProto(bytes)
 }
+
 // convertRawQuoteToProto converts raw quote in byte array format to proto.
 func convertRawQuoteToProto(rawQuote []byte) (*pb.QuoteV4, error) {
 	quote, err := abi.QuoteToProto(rawQuote)

--- a/client/client_linux.go
+++ b/client/client_linux.go
@@ -23,6 +23,8 @@ import (
 	"unsafe"
 
 	labi "github.com/google/go-tdx-guest/client/linuxabi"
+	"github.com/google/go-tdx-guest/external/go_configfs_tsm/configfs/linuxtsm"
+	"github.com/google/go-tdx-guest/external/go_configfs_tsm/report"
 	"golang.org/x/sys/unix"
 )
 
@@ -83,8 +85,9 @@ func (d *LinuxDevice) Ioctl(command uintptr, req any) (uintptr, error) {
 		abi.Finish(sreq)
 		if errno == unix.EBUSY {
 			return 0, errno
-		}
-		if errno != 0 {
+		} else if errno == unix.ENOTTY {
+			return 0, fmt.Errorf("invalid ioctl! use QuoteProvider to fetch attestation quote")
+		} else if errno != 0 {
 			return 0, errno
 		}
 		return result, nil
@@ -96,4 +99,30 @@ func (d *LinuxDevice) Ioctl(command uintptr, req any) (uintptr, error) {
 		return result, nil
 	}
 	return 0, fmt.Errorf("unexpected request value: %v", req)
+}
+
+// LinuxConfigFsQuoteProvider implements the QuoteProvider interface to fetch
+// attestation quote via ConfigFS.
+type LinuxConfigFsQuoteProvider struct{}
+// IsSupported checks if TSM client can be created to use ConfigFS system.
+func (p *LinuxConfigFsQuoteProvider) IsSupported() error {
+	_, err := linuxtsm.MakeClient()
+	return err
+}
+// GetRawQuote returns byte format attestation quote via ConfigFS.
+func (p *LinuxConfigFsQuoteProvider) GetRawQuote(reportData [64]byte) ([]uint8, error) {
+	req := &report.Request{
+		InBlob:     reportData[:],
+		GetAuxBlob: false,
+	}
+	resp, err := linuxtsm.GetReport(req)
+	if err != nil {
+		return nil, err
+	}
+	tdReport := resp.OutBlob
+	return tdReport, nil
+}
+// GetQuoteProvider returns an instance of LinuxConfigFsQuoteProvider.
+func GetQuoteProvider() (*LinuxConfigFsQuoteProvider, error) {
+	return &LinuxConfigFsQuoteProvider{}, nil
 }

--- a/client/client_linux.go
+++ b/client/client_linux.go
@@ -104,11 +104,13 @@ func (d *LinuxDevice) Ioctl(command uintptr, req any) (uintptr, error) {
 // LinuxConfigFsQuoteProvider implements the QuoteProvider interface to fetch
 // attestation quote via ConfigFS.
 type LinuxConfigFsQuoteProvider struct{}
+
 // IsSupported checks if TSM client can be created to use ConfigFS system.
 func (p *LinuxConfigFsQuoteProvider) IsSupported() error {
 	_, err := linuxtsm.MakeClient()
 	return err
 }
+
 // GetRawQuote returns byte format attestation quote via ConfigFS.
 func (p *LinuxConfigFsQuoteProvider) GetRawQuote(reportData [64]byte) ([]uint8, error) {
 	req := &report.Request{
@@ -122,6 +124,7 @@ func (p *LinuxConfigFsQuoteProvider) GetRawQuote(reportData [64]byte) ([]uint8, 
 	tdReport := resp.OutBlob
 	return tdReport, nil
 }
+
 // GetQuoteProvider returns an instance of LinuxConfigFsQuoteProvider.
 func GetQuoteProvider() (*LinuxConfigFsQuoteProvider, error) {
 	return &LinuxConfigFsQuoteProvider{}, nil

--- a/client/client_macos.go
+++ b/client/client_macos.go
@@ -49,14 +49,17 @@ func (*MacOSDevice) Ioctl(_ uintptr, _ any) (uintptr, error) {
 
 // MacOsConfigFsQuoteProvider implements the QuoteProvider interface to fetch attestation quote via ConfigFS.
 type MacOsConfigFsQuoteProvider struct{}
+
 // IsSupported is not supported on MacOS.
 func (p *MacOsConfigFsQuoteProvider) IsSupported() error {
 	return fmt.Errorf("MacOS is unsupported")
 }
+
 // GetRawQuote is not supported on MacOS.
 func (p *MacOsConfigFsQuoteProvider) GetRawQuote(reportData [64]byte) ([]uint8, error) {
 	return nil, fmt.Errorf("MacOS is unsupported")
 }
+
 // GetQuoteProvider is not supported on MacOS.
 func GetQuoteProvider() (*MacOsConfigFsQuoteProvider, error) {
 	return nil, fmt.Errorf("MacOS is unsupported")

--- a/client/client_macos.go
+++ b/client/client_macos.go
@@ -46,3 +46,18 @@ func (*MacOSDevice) Close() error {
 func (*MacOSDevice) Ioctl(_ uintptr, _ any) (uintptr, error) {
 	return 0, fmt.Errorf("MacOS is unsupported")
 }
+
+// MacOsConfigFsQuoteProvider implements the QuoteProvider interface to fetch attestation quote via ConfigFS.
+type MacOsConfigFsQuoteProvider struct{}
+// IsSupported is not supported on MacOS.
+func (p *MacOsConfigFsQuoteProvider) IsSupported() error {
+	return fmt.Errorf("MacOS is unsupported")
+}
+// GetRawQuote is not supported on MacOS.
+func (p *MacOsConfigFsQuoteProvider) GetRawQuote(reportData [64]byte) ([]uint8, error) {
+	return nil, fmt.Errorf("MacOS is unsupported")
+}
+// GetQuoteProvider is not supported on MacOS.
+func GetQuoteProvider() (*MacOsConfigFsQuoteProvider, error) {
+	return nil, fmt.Errorf("MacOS is unsupported")
+}

--- a/client/client_windows.go
+++ b/client/client_windows.go
@@ -43,3 +43,21 @@ func (*WindowsDevice) Ioctl(_ uintptr, _ any) (uintptr, error) {
 	// The GuestAttestation library on Windows is closed source.
 	return 0, fmt.Errorf("Windows is unsupported")
 }
+
+// WindowsConfigFsQuoteProvider implements the QuoteProvider interface to fetch attestation quote via ConfigFS.
+type WindowsConfigFsQuoteProvider struct{}
+
+// IsSupported is not supported on Windows.
+func (p *WindowsConfigFsQuoteProvider) IsSupported() error {
+	return fmt.Errorf("Windows is unsupported")
+}
+
+// GetRawQuote is not supported on Windows.
+func (p *WindowsConfigFsQuoteProvider) GetRawQuote(reportData [64]byte) ([]uint8, error) {
+	return nil, fmt.Errorf("Windows is unsupported")
+}
+
+// GetQuoteProvider is not supported on Windows.
+func GetQuoteProvider() (*WindowsConfigFsQuoteProvider, error) {
+	return nil, fmt.Errorf("Windows is unsupported")
+}

--- a/external/go_configfs_tsm/README.md
+++ b/external/go_configfs_tsm/README.md
@@ -1,0 +1,131 @@
+# go-configfs-tsm
+
+This library wraps the configfs/tsm Linux subsystem for Trusted Security Module operations.
+
+Please note that this is a temporary library added for now. NOT FOR EXTERNAL USE.
+
+## `report` library
+
+This library wraps the configfs/tsm/report subsystem for safely generating
+attestation reports.
+
+The TSM `report` subsystem provides a vendor-agnostic interface for collecting a
+signed document for the Trusted Execution Environment's (TEE) state for remote
+verification. For simplicity, we call this document an "attestation report",
+though other sources may sometimes refer to it as a "quote".
+
+Signing keys are expected to be rooted back to the manufacturer. Certificates
+may be present in the `auxblob` attribute or as part of the report in `outblob`.
+
+The core functionality of attestation report interaction is nonce in, report
+out. For testability, we abstract the file operations that are needed for
+creating configfs report entries, reading and writing attributes, and final
+reclaiming of resources.
+
+```golang
+func Get(client configfsi.Client, req *report.Request) (*report.Response, error)
+```
+
+Where
+
+```golang
+type Request struct {
+	InBlob     []byte
+	Privilege  *Privilege
+	GetAuxBlob bool
+}
+
+
+type Response struct {
+	Provider string
+	OutBlob  []byte
+	AuxBlob  []byte
+}
+
+type Privilege struct {
+	Level int
+}
+```
+
+The provider may not implement an `AuxBlob` delivery mechanism, so if
+`GetAuxBlob` is true, then `AuxBlob` still must be checked for length 0.
+
+### Errors
+
+Since this is a file-based system, there's always a chance that an operation may
+fail with a permission error. By default, the TSM system requires root access.
+
+The host may also add rate limiting to requests, such that an outblob read fails
+with `EBUSY`. The kernel may or may not try again on behalf of the user.
+
+Finally, due to the fact that the TSM report system only requests an attestation
+report when reading `outblob` or `auxblob`, there is a chance the input
+attributes may have been changed to unexpected values from an interfering
+process. This interference is a bug in user space that the kernel does not block
+for simplicity. Interference is evident through the `generation` attribute. When
+`generation` does not match the expectations that the `report` package tracks,
+`report.Get` returns a `*report.GenerationErr` or an error that wraps
+`*report.GenerationErr`.
+
+Use `func GetGenerationErr(error) *GenerationErr` to extract a `*GenerationErr`
+from an error if it is or contains a `*GenerationErr`. If present, the caller
+should try to identify the source of interference and remove it. Meanwhile, the
+caller may try again.
+
+## `configfsi.Client` interface
+
+Most users will only want to use the client from `linuxtsm.MakeClient`.
+
+A client on real hardware is just the filesystem, since the configfs
+interactions will interact with the hardware. In unit tests though, we can
+emulate the behavior that has been proposed in v7 of the patch series
+
+```golang
+type Client interface {
+	MkdirTemp(dir, pattern string) (string, error)
+	ReadFile(name string) ([]byte, error)
+	WriteFile(name string, contents []byte) error
+	RemoveAll(path string) error
+}
+```
+
+The `RemoveAll` function is the only oddly named method, since the real
+interface would just `rmdir` the report directory
+([`os.Remove`](https://pkg.go.dev/os#Remove) in Golang), even when there are
+apparent files underneath. Non-empty directory removal is generally not allowed,
+so the `RemoveAll` name is clearer with what it does.
+
+## `linuxtsm` package
+
+The `linuxtsm` package defines an implementation of `configfsi.Client` with
+
+```golang
+func MakeClient() (configfsi.Client, error)
+```
+
+For further convenience, `linuxtsm` provides an alias for `MakeClient` combined with `report.Get` as
+
+```golang
+func GetReport(req *report.Request) (*report.Response, error)
+```
+
+The usage is the same as for `report.Get`.
+
+## `faketsm` package
+
+The `faketsm.Client` implementation allows tests to provide custom behavior for subsystems by name:
+
+```golang
+type Client struct {
+	Subsystems map[string]configfsi.Client
+}
+```
+
+The `faketsm.ReportSubsystem` type implements a client that emulates the
+concurrent behavior and `generation` attribute semantics. To test negative
+behavior as well, the subsystem allows the user to override `Mkdir`, `ReadFile`,
+existing entries' values, and the error behavior of `WriteFile`.
+
+## Disclaimer
+
+This is not an officially supported Google product.

--- a/external/go_configfs_tsm/configfs/configfsi/configfsi.go
+++ b/external/go_configfs_tsm/configfs/configfsi/configfsi.go
@@ -1,0 +1,30 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package configfsi defines an interface for interaction with the TSM configfs subsystem.
+package configfsi
+
+// Client abstracts the filesystem operations for interacting with configfs files.
+type Client interface {
+	// MkdirTemp creates a new temporary directory in the directory dir and returns the pathname
+	// of the new directory. Pattern semantics follow os.MkdirTemp.
+	MkdirTemp(dir, pattern string) (string, error)
+	// ReadFile reads the named file and returns the contents.
+	ReadFile(name string) ([]byte, error)
+	// WriteFile writes data to the named file, creating it if necessary. The permissions
+	// are implementation-defined.
+	WriteFile(name string, contents []byte) error
+	// RemoveAll removes path and any children it contains.
+	RemoveAll(path string) error
+}

--- a/external/go_configfs_tsm/configfs/configfsi/parse.go
+++ b/external/go_configfs_tsm/configfs/configfsi/parse.go
@@ -1,0 +1,26 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configfsi
+
+import (
+	"strconv"
+	"strings"
+)
+
+// Kstrtouint returns the unsigned integer represented in data, following the same grammar
+// allowances as Linux, i.e., data may have a single trailing newline.
+func Kstrtouint(data []byte, base, bits int) (uint64, error) {
+	return strconv.ParseUint(strings.TrimRight(string(data), "\n"), base, bits)
+}

--- a/external/go_configfs_tsm/configfs/configfsi/path.go
+++ b/external/go_configfs_tsm/configfs/configfsi/path.go
@@ -1,0 +1,103 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configfsi
+
+import (
+	"fmt"
+	"io"
+	"path"
+	"strings"
+)
+
+const (
+	// TsmPrefix is the path to the configfs tsm system.
+	TsmPrefix = "/sys/kernel/config/tsm"
+
+	// How many random characters to use when replacing * in a temporary path pattern.
+	randomPathSize = 10
+)
+
+// TsmPath represents a configfs file path decomposed into the components
+// that are expected for TSM.
+type TsmPath struct {
+	// Subsystem is the TSM subsystem the path is targeting, e.g., "report"
+	Subsystem string
+	// Entry is the directory under the subsystem that represents a single
+	// user's interface with the subsystem.
+	Entry string
+	// Attribute is a file under Entry that may be readable or writable depending
+	// on its name.
+	Attribute string
+}
+
+// String returns the configfs path that the TsmPath stands for.
+func (p *TsmPath) String() string {
+	return path.Join(TsmPrefix, p.Subsystem, p.Entry, p.Attribute)
+}
+
+// ParseTsmPath decomposes a configfs path to TSM into its expected format, or returns
+// an error.
+func ParseTsmPath(filepath string) (*TsmPath, error) {
+	p := path.Clean(filepath)
+	if !strings.HasPrefix(p, TsmPrefix) {
+		return nil, fmt.Errorf("%q does not begin with %q", p, TsmPrefix)
+	}
+	// If just the tsm folder is given, there won't be a "/", but if there is a subpath,
+	// then it will have the leading "/".
+	rest := strings.TrimPrefix(strings.TrimPrefix(p, TsmPrefix), "/")
+	if rest == "" {
+		return nil, fmt.Errorf("%q does not contain a subsystem", p)
+	}
+
+	dir := path.Dir(rest)
+	file := path.Base(rest)
+	if dir == "." {
+		return &TsmPath{Subsystem: file}, nil
+	}
+	gdir := path.Dir(dir) // grand-dir
+	mfile := path.Base(dir)
+	if gdir == "." {
+		return &TsmPath{Subsystem: mfile, Entry: file}, nil
+	}
+	ggdir := path.Dir(gdir) // grand-grand-dir
+	subsystem := path.Base(gdir)
+	if ggdir != "." {
+		return nil, fmt.Errorf("%q suffix expected to be of form subsystem[/entry[/attribute]] (debug %q)", rest, ggdir)
+	}
+	return &TsmPath{Subsystem: subsystem, Entry: mfile, Attribute: file}, nil
+}
+
+func readableString(data []byte) string {
+	var sb strings.Builder
+	for _, b := range data {
+		sb.WriteRune(rune('0' + (b % 10)))
+	}
+	return sb.String()
+}
+
+// TempName returns a random filename following the pattern semantics
+// of os.MkdirTemp. Does not have a root directory.
+func TempName(rand io.Reader, pattern string) string {
+	data := make([]byte, randomPathSize)
+	if n, err := rand.Read(data); err != nil || n != len(data) {
+		return "rdfail"
+	}
+	randString := readableString(data)
+	lastAsterisk := strings.LastIndex(pattern, "*")
+	if lastAsterisk == -1 {
+		return pattern + randString
+	}
+	return pattern[0:lastAsterisk] + randString + pattern[lastAsterisk+1:]
+}

--- a/external/go_configfs_tsm/configfs/configfsi/path_test.go
+++ b/external/go_configfs_tsm/configfs/configfsi/path_test.go
@@ -1,0 +1,139 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configfsi
+
+import (
+	"crypto/rand"
+	"strings"
+	"testing"
+)
+
+func TestTsmPathString(t *testing.T) {
+	tcs := []struct {
+		input *TsmPath
+		want  string
+	}{
+		{input: &TsmPath{}, want: "/sys/kernel/config/tsm"},
+		{input: &TsmPath{Subsystem: "rebort"}, want: "/sys/kernel/config/tsm/rebort"},
+		{
+			input: &TsmPath{Subsystem: "repart", Entry: "j"},
+			want:  "/sys/kernel/config/tsm/repart/j",
+		},
+		{
+			input: &TsmPath{Subsystem: "report", Entry: "r", Attribute: "inblob"},
+			want:  "/sys/kernel/config/tsm/report/r/inblob",
+		},
+	}
+	for _, tc := range tcs {
+		got := tc.input.String()
+		if got != tc.want {
+			t.Errorf("%v.String() = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}
+
+func match(err error, want string) bool {
+	if err == nil && want == "" {
+		return true
+	}
+	return (err != nil && want != "" && strings.Contains(err.Error(), want))
+}
+
+func TestParseTsmPath(t *testing.T) {
+	tcs := []struct {
+		input   string
+		want    *TsmPath
+		wantErr string
+	}{
+		{
+			input:   "not/to/configfs",
+			wantErr: `"not/to/configfs" does not begin with "/sys/kernel/config/tsm"`,
+		},
+		{
+			input:   "///sys/kernel/config/tsm",
+			wantErr: `"/sys/kernel/config/tsm" does not contain a subsystem`,
+		},
+		{
+			input:   "/sys/kernel/config/tsm/report/is/way/too/long",
+			wantErr: `"report/is/way/too/long" suffix expected to be of form`,
+		},
+		{
+			input: "/sys/kernel/config/tsm/a",
+			want:  &TsmPath{Subsystem: "a"},
+		},
+		{
+			input: "/sys/kernel/config/tsm/a/b",
+			want:  &TsmPath{Subsystem: "a", Entry: "b"},
+		},
+		{
+			input: "/sys/kernel/config/tsm/a/b/c",
+			want:  &TsmPath{Subsystem: "a", Entry: "b", Attribute: "c"},
+		},
+	}
+	for _, tc := range tcs {
+		got, err := ParseTsmPath(tc.input)
+		if !match(err, tc.wantErr) {
+			t.Errorf("ParseTsmPath(%q) = %v, %v errored unexpectedly. Want %s",
+				tc.input, got, err, tc.wantErr)
+		}
+		if tc.wantErr == "" && *got != *tc.want {
+			t.Errorf("ParseTsmPath(%q) = %v, nil. Want %v", tc.input, *got, *tc.want)
+		}
+	}
+}
+
+func TestTempName(t *testing.T) {
+	tcs := []struct {
+		name       string
+		pattern    string
+		wantPrefix string
+		wantSuffix string
+	}{
+		{name: "empty"},
+		{
+			name:       "no asterisk",
+			pattern:    "hi",
+			wantPrefix: "hi",
+		},
+		{name: "1 asterisk at end",
+			pattern:    "friend*",
+			wantPrefix: "friend",
+		},
+		{name: "many asterisks",
+			pattern:    "friend*ly*monster",
+			wantPrefix: "friend*ly",
+			wantSuffix: "monster",
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			got := TempName(rand.Reader, tc.pattern)
+			wantReplaceLen := len(tc.pattern) + randomPathSize
+			if strings.LastIndex(tc.pattern, "*") != -1 {
+				wantReplaceLen-- // The * gets replaced, so subtract it.
+			}
+			if len(got) != wantReplaceLen {
+				t.Errorf("TempName(_, %q) = %q, whose length is not %d", tc.pattern, got, wantReplaceLen)
+			}
+			if !strings.HasPrefix(got, tc.wantPrefix) {
+				t.Errorf("TempName(_, %q) = %q, does not have prefix %q", tc.pattern, got, tc.wantPrefix)
+			}
+			if !strings.HasSuffix(got, tc.wantSuffix) {
+				t.Errorf("TempName(_, %q) = %q, does not have suffix %q", tc.pattern, got, tc.wantSuffix)
+			}
+		})
+	}
+
+}

--- a/external/go_configfs_tsm/configfs/faketsm/fakereport.go
+++ b/external/go_configfs_tsm/configfs/faketsm/fakereport.go
@@ -1,0 +1,322 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package faketsm
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"sync"
+	"syscall"
+	"unicode/utf8"
+
+	"github.com/google/go-tdx-guest/external/go_configfs_tsm/configfs/configfsi"
+)
+
+// ErrPrivLevelFormat to store error due to incorrect privilege level.
+var ErrPrivLevelFormat = errors.New("privlevel must be 0-3")
+
+const (
+	// subsystemName is the expected subsystem path entry under tsm for reports.
+	subsystemName = "report"
+	tsmInBlobSize = 64
+	renderBase    = 10
+)
+
+// ReportAttributeState rewrites a writable attribute's value state. May also be readable.
+type ReportAttributeState struct {
+	Value     []byte
+	ReadWrite bool
+}
+
+// ReportEntry represents a report entry in the TSM report subsystem.
+type ReportEntry struct {
+	mu              sync.RWMutex
+	destroyed       bool
+	ReadGeneration  uint64
+	WriteGeneration uint64
+	// InAttrs represents the value of all WO attributes by name (relative to entry).
+	// All possible attributes ought to be mapped on creation.
+	InAttrs map[string]*ReportAttributeState
+	// ROAttrs is populated on ReadFile under mu and acts as a cache when
+	// generations align before calling ReadAttr.
+	ROAttrs map[string][]byte
+}
+
+// ReportSubsystem represents the general behavior of the configfs-tsm report subsystem
+type ReportSubsystem struct {
+	// CheckInAttr called on any WriteFile to an attribute. If non-nil, WriteFile returns
+	// the error instead of writing. Called while holding client and entry locks.
+	CheckInAttr func(e *ReportEntry, attr string, contents []byte) error
+	// ReadAttr is called on any non-InAddr key while holding the client and entry locks.
+	ReadAttr func(e *ReportEntry, attr string) ([]byte, error)
+	// MakeEntry returns a fresh entry with all expected InAttrs. Called while holding
+	// the client lock.
+	MakeEntry func() *ReportEntry
+	mu        sync.RWMutex
+	Entries   map[string]*ReportEntry
+	// Random is the source of randomness to use for MkdirTemp
+	Random io.Reader
+}
+
+// Called while mu is held
+func (e *ReportEntry) tryAdvanceWriteGeneration() error {
+	if e.destroyed {
+		return os.ErrNotExist
+	}
+	if e.WriteGeneration == e.ReadGeneration-1 {
+		return syscall.EBUSY
+	}
+	e.WriteGeneration++
+	return nil
+}
+
+// MkdirTemp creates a new temporary directory in the directory dir and returns the pathname
+// of the new directory. Pattern semantics follow os.MkdirTemp.
+func (r *ReportSubsystem) MkdirTemp(dir, pattern string) (string, error) {
+	p, err := configfsi.ParseTsmPath(dir)
+	if err != nil {
+		return "", fmt.Errorf("MkdirTemp: %v", err)
+	}
+	if p.Entry != "" {
+		return "", fmt.Errorf("report entry %q cannot have subdirectories", dir)
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.Entries == nil {
+		r.Entries = make(map[string]*ReportEntry)
+	}
+	name := configfsi.TempName(r.Random, pattern)
+	if _, ok := r.Entries[name]; ok {
+		return "", os.ErrExist
+	}
+	r.Entries[name] = r.MakeEntry()
+	return path.Join(dir, name), nil
+}
+
+func (e *ReportEntry) readCached(attr string) ([]byte, error) {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	if e.destroyed {
+		return nil, os.ErrNotExist
+	}
+	// The only special attribute is "generation", since it peers into the
+	// mechanics of mutation.
+	if attr == "generation" {
+		return []byte(fmt.Sprintf("%d\n", e.WriteGeneration)), nil
+	}
+	if e.ReadGeneration != e.WriteGeneration {
+		return nil, syscall.EWOULDBLOCK
+	}
+	if a, ok := e.InAttrs[attr]; ok {
+		if !a.ReadWrite {
+			return nil, fmt.Errorf("%q is not readable", attr)
+		}
+		dup := make([]byte, len(a.Value))
+		copy(dup, a.Value)
+		return dup, nil
+	}
+	if e.ROAttrs != nil {
+		if a, ok := e.ROAttrs[attr]; ok {
+			if len(a) != 0 {
+				dup := make([]byte, len(a))
+				copy(dup, a)
+				return dup, nil
+			}
+			return nil, nil
+		}
+	}
+	return nil, os.ErrNotExist
+
+}
+
+// ReadFile reads the named file and returns the contents.
+func (r *ReportSubsystem) ReadFile(name string) ([]byte, error) {
+	p, err := configfsi.ParseTsmPath(name)
+	if err != nil {
+		return nil, fmt.Errorf("ReadFile: %v", err)
+	}
+	if p.Attribute == "" {
+		return nil, fmt.Errorf("not an attribute: %q", name)
+	}
+	r.mu.RLock()
+	if r.Entries == nil {
+		return nil, os.ErrNotExist
+	}
+	e, ok := r.Entries[p.Entry]
+	if !ok {
+		r.mu.RUnlock()
+		return nil, os.ErrNotExist
+	}
+	r.mu.RUnlock()
+	if b, err := e.readCached(p.Attribute); (err == nil && len(b) != 0) || err != syscall.EWOULDBLOCK {
+		return b, err
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.ROAttrs == nil {
+		e.ROAttrs = make(map[string][]byte)
+	}
+	// It's possible another thread has populated the report between RUnlock and Lock.
+	if b, ok := e.ROAttrs[p.Attribute]; ok && e.ReadGeneration == e.WriteGeneration {
+		return b, nil
+	}
+	e.ROAttrs[p.Attribute] = nil
+	b, err := r.ReadAttr(e, p.Attribute)
+	if err != nil {
+		return nil, fmt.Errorf("ReadAttr(_, %q): %v", p.Attribute, err)
+	}
+	e.ROAttrs[p.Attribute] = b
+	return b, nil
+}
+
+// WriteFile writes data to the named file, creating it if necessary. The permissions
+// are implementation-defined.
+func (r *ReportSubsystem) WriteFile(name string, contents []byte) error {
+	p, err := configfsi.ParseTsmPath(name)
+	if err != nil {
+		return fmt.Errorf("WriteFile: %v", err)
+	}
+	if p.Attribute == "" {
+		return fmt.Errorf("cannot write to non-attribute: %q", name)
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	e, ok := r.Entries[p.Entry]
+	if !ok {
+		return os.ErrNotExist
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.destroyed {
+		return os.ErrNotExist
+	}
+	if err := r.CheckInAttr(e, p.Attribute, contents); err != nil {
+		return fmt.Errorf("could not write %q: %v", name, err)
+	}
+	if err := e.tryAdvanceWriteGeneration(); err != nil {
+		return err
+	}
+	e.InAttrs[p.Attribute].Value = contents
+	return nil
+}
+
+// RemoveAll removes path and any children it contains.
+func (r *ReportSubsystem) RemoveAll(name string) error {
+	p, err := configfsi.ParseTsmPath(name)
+	if err != nil {
+		return fmt.Errorf("RemoveAll: %v", err)
+	}
+	if p.Attribute != "" || p.Entry == "" || p.Subsystem != subsystemName {
+		return fmt.Errorf("RemoveAll(%q) expected report subsystem entry path", name)
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.Entries == nil {
+		return os.ErrNotExist
+	}
+	e, ok := r.Entries[p.Entry]
+	if !ok {
+		return os.ErrNotExist
+	}
+	// Don't delete while another operation is using the entry.
+	e.mu.Lock()
+	e.destroyed = true
+	delete(r.Entries, p.Entry)
+	e.mu.Unlock()
+	return nil
+}
+
+func renderOutBlob(privlevel, inblob []byte) []byte {
+	// checkv7 already ensures this does not error
+	priv, _ := configfsi.Kstrtouint(privlevel, renderBase, 2)
+	return []byte(fmt.Sprintf("privlevel: %d\ninblob: %s",
+		priv,
+		hex.EncodeToString(inblob)))
+}
+
+func readV7(privlevelFloor uint) func(*ReportEntry, string) ([]byte, error) {
+	return func(e *ReportEntry, attr string) ([]byte, error) {
+		switch attr {
+		case "provider":
+			return []byte("fake\n"), nil
+		case "auxblob":
+			return []byte(`auxblob`), nil
+		case "outblob":
+			privlevel := []byte("<missing>")
+			if a, ok := e.InAttrs["privlevel"]; ok && len(a.Value) > 0 {
+				privlevel = a.Value
+			}
+			inblob, ok := e.InAttrs["inblob"]
+			if !ok || len(inblob.Value) == 0 {
+				return nil, syscall.EINVAL
+			}
+			return renderOutBlob(privlevel, inblob.Value), nil
+		case "privlevel_floor":
+			return []byte(fmt.Sprintf("%d\n", privlevelFloor)), nil
+		}
+		return nil, os.ErrNotExist
+	}
+}
+
+func makeV7() *ReportEntry {
+	return &ReportEntry{
+		InAttrs: map[string]*ReportAttributeState{
+			"privlevel": {Value: []byte("0\n")},
+			"inblob":    {},
+		},
+	}
+}
+
+func checkV7(privlevelFloor uint) func(*ReportEntry, string, []byte) error {
+	return func(e *ReportEntry, attr string, contents []byte) error {
+		switch attr {
+		case "inblob":
+			if len(contents) > tsmInBlobSize {
+				return syscall.EINVAL
+			}
+		case "privlevel":
+			if !utf8.Valid(contents) {
+				return ErrPrivLevelFormat
+			}
+			level, err := configfsi.Kstrtouint(contents, renderBase, 2)
+			if err != nil {
+				return ErrPrivLevelFormat
+			}
+			if uint(level) < privlevelFloor {
+				return fmt.Errorf("privlevel %d cannot be less than %d",
+					level, privlevelFloor)
+			}
+		default:
+			return fmt.Errorf("unwritable attribute: %q", attr)
+		}
+		return nil
+	}
+}
+
+// ReportV7 returns an empty report subsystem with attributes as specified in the configfs-tsm
+// Patch v7 series.
+func ReportV7(privlevelFloor uint) *ReportSubsystem {
+	return &ReportSubsystem{
+		MakeEntry:   makeV7,
+		ReadAttr:    readV7(privlevelFloor),
+		CheckInAttr: checkV7(privlevelFloor),
+		Random:      rand.Reader,
+	}
+}

--- a/external/go_configfs_tsm/configfs/faketsm/fakereport_test.go
+++ b/external/go_configfs_tsm/configfs/faketsm/fakereport_test.go
@@ -101,26 +101,26 @@ func runInterference(t testing.TB, c configfsi.Client, entryPath string, tc *run
 	tc.done <- 0
 }
 
-func runNoninterference(t testing.TB, c configfsi.Client, tc *runner) {
-	t.Helper()
-	for i := 0; i < tc.iterations; i++ {
-		nonce := makeNonce(tc.id)
-		resp, err := report.Get(c, &report.Request{
-			InBlob:    nonce,
-			Privilege: &report.Privilege{Level: (tc.id % 4)},
-		})
-		if err == nil {
-			err = checkOutblobExpectation(nonce, (tc.id % 4), resp.OutBlob)
-		}
-		if err != nil {
-			t.Error(err)
-			tc.done <- 1
-			return
-		}
-	}
-	t.Logf("Posting done for %d", tc.id)
-	tc.done <- 0
-}
+// func runNoninterference(t testing.TB, c configfsi.Client, tc *runner) {
+// 	t.Helper()
+// 	for i := 0; i < tc.iterations; i++ {
+// 		nonce := makeNonce(tc.id)
+// 		resp, err := report.Get(c, &report.Request{
+// 			InBlob:    nonce,
+// 			Privilege: &report.Privilege{Level: (tc.id % 4)},
+// 		})
+// 		if err == nil {
+// 			err = checkOutblobExpectation(nonce, (tc.id % 4), resp.OutBlob)
+// 		}
+// 		if err != nil {
+// 			t.Error(err)
+// 			tc.done <- 1
+// 			return
+// 		}
+// 	}
+// 	t.Logf("Posting done for %d", tc.id)
+// 	tc.done <- 0
+// }
 
 // clients-many concurrent routines attempt to get an output on the same entry with
 // different inblobs.
@@ -151,24 +151,24 @@ func nonceAnonceB(t testing.TB, clients, iterations int) {
 	t.Logf("doooone")
 }
 
-func noninterferenceByDesign(t testing.TB, clients, iterations int) {
-	t.Helper()
-	c := ReportV7(0)
-	complete := make(chan int)
-	for i := 0; i < clients; i++ {
-		go runNoninterference(t, c, &runner{
-			iterations: iterations,
-			id:         uint(i),
-			done:       complete})
-	}
-	// Each client should write to the channel.
-	for i := 0; i < clients; i++ {
-		code := <-complete
-		if code == 1 {
-			t.Fatalf("early failure")
-		}
-	}
-}
+// func noninterferenceByDesign(t testing.TB, clients, iterations int) {
+// 	t.Helper()
+// 	c := ReportV7(0)
+// 	complete := make(chan int)
+// 	for i := 0; i < clients; i++ {
+// 		go runNoninterference(t, c, &runner{
+// 			iterations: iterations,
+// 			id:         uint(i),
+// 			done:       complete})
+// 	}
+// 	// Each client should write to the channel.
+// 	for i := 0; i < clients; i++ {
+// 		code := <-complete
+// 		if code == 1 {
+// 			t.Fatalf("early failure")
+// 		}
+// 	}
+// }
 
 func BenchmarkReportGenerationInterference(b *testing.B) {
 	nonceAnonceB(b, 4, b.N)

--- a/external/go_configfs_tsm/configfs/faketsm/fakereport_test.go
+++ b/external/go_configfs_tsm/configfs/faketsm/fakereport_test.go
@@ -50,7 +50,7 @@ func checkErr(err error) (bool, error) {
 	return false, nil
 }
 
-func runIteration(t testing.TB, c configfsi.Client, r *report.OpenReport, tc *runner) error {
+func runIteration(t testing.TB, _ configfsi.Client, r *report.OpenReport, tc *runner) error {
 	t.Helper()
 	nonce := makeNonce(tc.id)
 	t.Logf("Writing inblob %v", nonce)

--- a/external/go_configfs_tsm/configfs/faketsm/fakereport_test.go
+++ b/external/go_configfs_tsm/configfs/faketsm/fakereport_test.go
@@ -1,0 +1,179 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package faketsm
+
+import (
+	"bytes"
+	"fmt"
+	"math/big"
+	"path"
+	"testing"
+
+	"github.com/google/go-tdx-guest/external/go_configfs_tsm/configfs/configfsi"
+	"github.com/google/go-tdx-guest/external/go_configfs_tsm/report"
+)
+
+func checkOutblobExpectation(inblob []byte, privlevel uint, outblob []byte) error {
+	want := renderOutBlob([]byte(fmt.Sprintf("%d\n", privlevel)), inblob)
+	if !bytes.Equal(want, outblob) {
+		return fmt.Errorf("got %q, want %q", string(outblob), string(want))
+	}
+	return nil
+}
+
+func makeNonce(id uint) []byte {
+	// The nonce is currently expected to always be size 64.
+	result := make([]byte, 64)
+	copy(result, []byte(big.NewInt(int64(id)).String()))
+	return result
+}
+
+func checkErr(err error) (bool, error) {
+	if err != nil {
+		if err := report.GetGenerationErr(err); err != nil {
+			return true, nil
+		}
+		return false, err
+	}
+	return false, nil
+}
+
+func runIteration(t testing.TB, c configfsi.Client, r *report.OpenReport, tc *runner) error {
+	t.Helper()
+	nonce := makeNonce(tc.id)
+	t.Logf("Writing inblob %v", nonce)
+	if err := r.WriteOption("inblob", nonce); err != nil {
+		return fmt.Errorf("could not write inblob in %d: %v", tc.id, err)
+	}
+	t.Logf("Writing privlevel %d", (tc.id % 4))
+	if err := r.WriteOption("privlevel", []byte(fmt.Sprintf("%d", (tc.id%4)))); err != nil {
+		return fmt.Errorf("could not set privlevel: %v", err)
+	}
+	t.Logf("Reading outblob")
+	out, err := r.ReadOption("outblob")
+	if done, err := checkErr(err); done || err != nil {
+		if err != nil {
+			return fmt.Errorf("outblob read on client %d failed: %v", tc.id, err)
+		}
+		return nil
+	}
+	t.Logf("Checking outblob %v", out)
+	if err := checkOutblobExpectation(nonce, (tc.id % 4), out); err != nil {
+		return fmt.Errorf("attestation invariant violated: %v", err)
+	}
+	return nil
+}
+
+type runner struct {
+	iterations int
+	id         uint
+	done       chan int
+}
+
+func runInterference(t testing.TB, c configfsi.Client, entryPath string, tc *runner) {
+	t.Helper()
+	for i := 0; i < tc.iterations; i++ {
+		r, err := report.UnsafeWrap(c, entryPath)
+		if err != nil {
+			t.Errorf("could not create report entry: %v", err)
+			tc.done <- 1
+			return
+		}
+		if err := runIteration(t, c, r, tc); err != nil {
+			t.Error(err)
+			tc.done <- 1
+			return
+		}
+	}
+	t.Logf("Posting done for %d", tc.id)
+	tc.done <- 0
+}
+
+func runNoninterference(t testing.TB, c configfsi.Client, tc *runner) {
+	t.Helper()
+	for i := 0; i < tc.iterations; i++ {
+		nonce := makeNonce(tc.id)
+		resp, err := report.Get(c, &report.Request{
+			InBlob:    nonce,
+			Privilege: &report.Privilege{Level: (tc.id % 4)},
+		})
+		if err == nil {
+			err = checkOutblobExpectation(nonce, (tc.id % 4), resp.OutBlob)
+		}
+		if err != nil {
+			t.Error(err)
+			tc.done <- 1
+			return
+		}
+	}
+	t.Logf("Posting done for %d", tc.id)
+	tc.done <- 0
+}
+
+// clients-many concurrent routines attempt to get an output on the same entry with
+// different inblobs.
+func nonceAnonceB(t testing.TB, clients, iterations int) {
+	t.Helper()
+	c := ReportV7(0)
+	entryPath, err := c.MkdirTemp(path.Join(configfsi.TsmPrefix, "report"), "entry")
+	if err != nil {
+		t.Fatalf("could not create entry: %v", err)
+	}
+	t.Logf("made entry %s", entryPath)
+	defer c.RemoveAll(entryPath)
+
+	complete := make(chan int)
+	for i := 0; i < clients; i++ {
+		go runInterference(t, c, entryPath, &runner{
+			iterations: iterations,
+			id:         uint(i),
+			done:       complete})
+	}
+	// Each client should write to the channel.
+	for i := 0; i < clients; i++ {
+		code := <-complete
+		if code == 1 {
+			t.Fatalf("early failure")
+		}
+	}
+	t.Logf("doooone")
+}
+
+func noninterferenceByDesign(t testing.TB, clients, iterations int) {
+	t.Helper()
+	c := ReportV7(0)
+	complete := make(chan int)
+	for i := 0; i < clients; i++ {
+		go runNoninterference(t, c, &runner{
+			iterations: iterations,
+			id:         uint(i),
+			done:       complete})
+	}
+	// Each client should write to the channel.
+	for i := 0; i < clients; i++ {
+		code := <-complete
+		if code == 1 {
+			t.Fatalf("early failure")
+		}
+	}
+}
+
+func BenchmarkReportGenerationInterference(b *testing.B) {
+	nonceAnonceB(b, 4, b.N)
+}
+
+func BenchmarkReportGenerationNoninterference(b *testing.B) {
+	nonceAnonceB(b, 20, b.N)
+}

--- a/external/go_configfs_tsm/configfs/faketsm/faketsm.go
+++ b/external/go_configfs_tsm/configfs/faketsm/faketsm.go
@@ -1,0 +1,87 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package faketsm defines a configfsi.Client for faking TSM behavior.
+// The provider attribute returns "fake" and the attestation report format
+// is just the state of the attributes. The certificate blob is part of the
+// Client definition.
+package faketsm
+
+import (
+	"fmt"
+
+	"github.com/google/go-tdx-guest/external/go_configfs_tsm/configfs/configfsi"
+)
+
+// Client provides a "fake" provider for configfs to emulate the /sys/kernel/config/tsm behavior.
+// Dispatches to specialized subsystem Client interfaces.
+type Client struct {
+	Subsystems map[string]configfsi.Client
+}
+
+func (c *Client) getSubsystem(name string) (configfsi.Client, error) {
+	p, err := configfsi.ParseTsmPath(name)
+	if err != nil {
+		return nil, fmt.Errorf("getSubsystem: %v", err)
+	}
+	if p.Subsystem == "" {
+		return nil, fmt.Errorf("faketsm: expected tsm subsystem in %q", name)
+	}
+	sub, ok := c.Subsystems[p.Subsystem]
+	if !ok {
+		return nil, fmt.Errorf("faketsm: unsupported subsystem %q", p.Subsystem)
+	}
+	return sub, nil
+}
+
+// MkdirTemp creates a new temporary directory in the directory dir and returns the pathname
+// of the new directory. Pattern semantics follow os.MkdirTemp.
+func (c *Client) MkdirTemp(dir, pattern string) (string, error) {
+	if dir == "" {
+		return "", fmt.Errorf("faketsm doesn't implement empty directory behavior")
+	}
+	sub, err := c.getSubsystem(dir)
+	if err != nil {
+		return "", err
+	}
+	return sub.MkdirTemp(dir, pattern)
+}
+
+// ReadFile reads the named file and returns the contents.
+func (c *Client) ReadFile(name string) ([]byte, error) {
+	sub, err := c.getSubsystem(name)
+	if err != nil {
+		return nil, err
+	}
+	return sub.ReadFile(name)
+}
+
+// WriteFile writes data to the named file, creating it if necessary. The permissions
+// are implementation-defined.
+func (c *Client) WriteFile(name string, contents []byte) error {
+	sub, err := c.getSubsystem(name)
+	if err != nil {
+		return err
+	}
+	return sub.WriteFile(name, contents)
+}
+
+// RemoveAll removes path and any children it contains.
+func (c *Client) RemoveAll(name string) error {
+	sub, err := c.getSubsystem(name)
+	if err != nil {
+		return err
+	}
+	return sub.RemoveAll(name)
+}

--- a/external/go_configfs_tsm/configfs/linuxtsm/aliases.go
+++ b/external/go_configfs_tsm/configfs/linuxtsm/aliases.go
@@ -1,0 +1,38 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package linuxtsm
+
+// The aliases.go file is for "convenience" functions when folks only want to use the
+// Linux client.
+
+import (
+	"github.com/google/go-tdx-guest/external/go_configfs_tsm/report"
+	"go.uber.org/multierr"
+)
+
+// GetReport returns a one-shot configfs-tsm report given a report request.
+func GetReport(req *report.Request) (*report.Response, error) {
+	var err error
+	client, err := MakeClient()
+	if err != nil {
+		return nil, err
+	}
+	r, err := report.Create(client, req)
+	if err != nil {
+		return nil, err
+	}
+	response, err := r.Get()
+	return response, multierr.Combine(r.Destroy(), err)
+}

--- a/external/go_configfs_tsm/configfs/linuxtsm/linuxtsm.go
+++ b/external/go_configfs_tsm/configfs/linuxtsm/linuxtsm.go
@@ -1,0 +1,63 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package linuxtsm defines a configfsi.Client for Linux OS operations on configfs.
+package linuxtsm
+
+import (
+	"fmt"
+	"os"
+	"path"
+
+	"github.com/google/go-tdx-guest/external/go_configfs_tsm/configfs/configfsi"
+)
+
+// client provides configfsi.Client for /sys/kernel/config/tsm file operations in Linux.
+type client struct{}
+
+// MkdirTemp creates a new temporary directory in the directory dir and returns the pathname
+// of the new directory. Pattern semantics follow os.MkdirTemp.
+func (*client) MkdirTemp(dir, pattern string) (string, error) {
+	return os.MkdirTemp(dir, pattern)
+}
+
+// ReadFile reads the named file and returns the contents.
+func (*client) ReadFile(name string) ([]byte, error) {
+	return os.ReadFile(name)
+}
+
+// WriteFile writes data to the named file, creating it if necessary. The permissions
+// are implementation-defined.
+func (*client) WriteFile(name string, contents []byte) error {
+	return os.WriteFile(name, contents, 0220)
+}
+
+// RemoveAll removes path and any children it contains.
+func (*client) RemoveAll(path string) error {
+	return os.Remove(path)
+}
+
+// MakeClient returns a "real" client for using configfs for TSM use.
+func MakeClient() (configfsi.Client, error) {
+	// Linux client expects just the "report" subsystem for now.
+	checkPath := path.Join(configfsi.TsmPrefix, "report")
+	info, err := os.Stat(checkPath)
+	if err != nil {
+		return nil, err
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("expected %s to be a directory", checkPath)
+	}
+	return &client{}, nil
+}

--- a/external/go_configfs_tsm/report/report.go
+++ b/external/go_configfs_tsm/report/report.go
@@ -1,0 +1,232 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package report provides an API to the configfs/tsm/report subsystem for collecting
+// attestation reports and associated certificates.
+package report
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/google/go-tdx-guest/external/go_configfs_tsm/configfs/configfsi"
+	"go.uber.org/multierr"
+)
+
+const (
+	subsystem           = "report"
+	subsystemPath       = configfsi.TsmPrefix + "/" + subsystem
+	numberAttributeBase = 10
+)
+
+// Privilege represents the requested privilege information at which a report should
+// be created.
+type Privilege struct {
+	Level uint
+}
+
+// Request represents an open request for an attestation report.
+type Request struct {
+	InBlob     []byte
+	Privilege  *Privilege
+	GetAuxBlob bool
+}
+
+// OpenReport represents a created tsm report subtree with internal expectations for the generation.
+type OpenReport struct {
+	InBlob             []byte
+	Privilege          *Privilege
+	GetAuxBlob         bool
+	entry              *configfsi.TsmPath
+	expectedGeneration uint64
+	client             configfsi.Client
+}
+
+// Response represents a common case response for getting at attestation report to avoid
+// multiple attribute access calls.
+type Response struct {
+	Provider string
+	OutBlob  []byte
+	AuxBlob  []byte
+}
+
+// GenerationErr is returned when an attribute's value is invalid due to mismatched expectations
+// on the number of writes to a report entry.
+type GenerationErr struct {
+	Got       uint64
+	Want      uint64
+	Attribute string
+}
+
+// Error returns the human-readable explanation for the error.
+func (e *GenerationErr) Error() string {
+	return fmt.Sprintf("report generation was %d when expecting %d while reading property %q",
+		e.Got, e.Want, e.Attribute)
+}
+
+// GetGenerationErr returns the GenerationErr contained in an error with 0 or 1 wraps.
+func GetGenerationErr(err error) *GenerationErr {
+	var result *GenerationErr
+	if err != nil && (errors.As(err, &result) || errors.As(errors.Unwrap(err), &result)) {
+		return result
+	}
+	return nil
+}
+
+func (r *OpenReport) attribute(subtree string) string {
+	a := *r.entry
+	a.Attribute = subtree
+	return a.String()
+}
+
+func readUint64File(client configfsi.Client, p string) (uint64, error) {
+	data, err := client.ReadFile(p)
+	if err != nil {
+		return 0, fmt.Errorf("could not read %q: %v", p, err)
+	}
+	return configfsi.Kstrtouint(data, numberAttributeBase, 64)
+}
+
+// CreateOpenReport returns a newly-created entry in the configfs-tsm report subtree with an initial
+// expected generation value.
+func CreateOpenReport(client configfsi.Client) (*OpenReport, error) {
+	entry, err := client.MkdirTemp(subsystemPath, "entry")
+	if err != nil {
+		return nil, fmt.Errorf("could not create report entry in configfs: %v", err)
+	}
+	return UnsafeWrap(client, entry)
+}
+
+// UnsafeWrap returns a new OpenReport for a given report entry.
+func UnsafeWrap(client configfsi.Client, entryPath string) (r *OpenReport, err error) {
+	p, _ := configfsi.ParseTsmPath(entryPath)
+	r = &OpenReport{
+		client: client,
+		entry:  &configfsi.TsmPath{Subsystem: subsystem, Entry: p.Entry},
+	}
+	r.expectedGeneration, err = readUint64File(client, r.attribute("generation"))
+	if err != nil {
+		// The report was created but couldn't be properly initialized.
+		return nil, multierr.Combine(r.Destroy(), err)
+	}
+	return r, nil
+}
+
+// Create returns a newly-created entry in the configfs-tsm report subtree with common inputs
+// for the Get() method initialized from the request.
+func Create(client configfsi.Client, req *Request) (*OpenReport, error) {
+	r, err := CreateOpenReport(client)
+	if err != nil {
+		return nil, err
+	}
+	r.InBlob = req.InBlob // InBlob is not a copy!
+	r.Privilege = req.Privilege
+	r.GetAuxBlob = req.GetAuxBlob
+	return r, nil
+}
+
+// Destroy returns an error if the configfs report subtree cannot be removed. Will not error for
+// partially initialized or already-destroyed reports.
+func (r *OpenReport) Destroy() error {
+	if r.entry != nil {
+		if err := r.client.RemoveAll(r.entry.String()); err != nil {
+			return err
+		}
+		r.entry = nil
+	}
+	return nil
+}
+
+// PrivilegeLevelFloor returns the privlevel_floor attribute interpreted as the uint type it is.
+func (r *OpenReport) PrivilegeLevelFloor() (uint, error) {
+	data, err := r.ReadOption("privlevel_floor")
+	if err != nil {
+		return 0, err
+	}
+	i, err := configfsi.Kstrtouint(data, numberAttributeBase, 32)
+	if err != nil {
+		return 0, fmt.Errorf("could not parse privlevel_floor data %v as int: %v", data, err)
+	}
+	return uint(i), nil
+}
+
+// WriteOption sets a configfs report option to the provided data and internally tracks
+// the generation that should be expected on the next ReadOption.
+func (r *OpenReport) WriteOption(subtree string, data []byte) error {
+	if err := r.client.WriteFile(r.attribute(subtree), data); err != nil {
+		return fmt.Errorf("could not write report %s: %v", subtree, err)
+	}
+	r.expectedGeneration++
+	return nil
+}
+
+// ReadOption is a safe accessor to a readable attribute of a report. Returns an error if there is
+// any detected tampering to the ongoing request.
+func (r *OpenReport) ReadOption(subtree string) ([]byte, error) {
+	data, err := r.client.ReadFile(r.attribute(subtree))
+	if err != nil {
+		return nil, fmt.Errorf("could not read report property %q: %v", subtree, err)
+	}
+	gotGeneration, err := readUint64File(r.client, r.attribute("generation"))
+	if err != nil {
+		return nil, err
+	}
+	if gotGeneration != r.expectedGeneration {
+		return nil, &GenerationErr{Got: gotGeneration, Want: r.expectedGeneration, Attribute: subtree}
+	}
+	return data, nil
+}
+
+// Get returns the requested report data after initializing the context to the expected
+// parameters. Returns an error if the kernel reports an error or there is a difference in expected
+// generation value.
+func (r *OpenReport) Get() (*Response, error) {
+	var err error
+	if err := r.WriteOption("inblob", r.InBlob); err != nil {
+		return nil, err
+	}
+	if r.Privilege != nil {
+		if err := r.WriteOption("privlevel", []byte(fmt.Sprintf("%d", r.Privilege.Level))); err != nil {
+			return nil, err
+		}
+	}
+	resp := &Response{}
+	if r.GetAuxBlob {
+		resp.AuxBlob, err = r.ReadOption("auxblob")
+		if err != nil {
+			return nil, fmt.Errorf("could not read report auxblob: %w", err)
+		}
+	}
+	resp.OutBlob, err = r.ReadOption("outblob")
+	if err != nil {
+		return nil, fmt.Errorf("could not read report outblob: %w", err)
+	}
+	providerData, err := r.ReadOption("provider")
+	if err != nil {
+		return nil, err
+	}
+	resp.Provider = string(providerData)
+	return resp, nil
+}
+
+// Get returns a one-shot configfs-tsm report given a report request.
+func Get(client configfsi.Client, req *Request) (*Response, error) {
+	var err error
+	r, err := Create(client, req)
+	if err != nil {
+		return nil, err
+	}
+	response, err := r.Get()
+	return response, multierr.Combine(r.Destroy(), err)
+}

--- a/external/go_configfs_tsm/report/report_test.go
+++ b/external/go_configfs_tsm/report/report_test.go
@@ -1,0 +1,95 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package report
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/google/go-tdx-guest/external/go_configfs_tsm/configfs/configfsi"
+	"github.com/google/go-tdx-guest/external/go_configfs_tsm/configfs/faketsm"
+)
+
+func TestGet(t *testing.T) {
+	c := &faketsm.Client{Subsystems: map[string]configfsi.Client{"report": faketsm.ReportV7(0)}}
+	req := &Request{
+		InBlob:     []byte("lessthan64bytesok"),
+		GetAuxBlob: true,
+	}
+	resp, err := Get(c, req)
+	if err != nil {
+		t.Fatalf("Get(%+v) = %+v, %v, want nil", req, resp, err)
+	}
+	wantOut := "privlevel: 0\ninblob: 6c6573737468616e363462797465736f6b"
+	if !bytes.Equal(resp.OutBlob, []byte(wantOut)) {
+		t.Errorf("OutBlob %v is not %v", string(resp.OutBlob), wantOut)
+	}
+	wantProvider := "fake\n"
+	if resp.Provider != wantProvider {
+		t.Errorf("provider = %q, want %q", resp.Provider, wantProvider)
+	}
+	if !bytes.Equal(resp.AuxBlob, []byte(`auxblob`)) {
+		t.Errorf("auxblob = %v, want %v", resp.AuxBlob, []byte(`auxblob`))
+	}
+}
+
+func TestGetErr(t *testing.T) {
+	tcs := []struct {
+		name    string
+		req     *Request
+		floor   uint
+		wantErr string
+	}{
+		{
+			name: "inblob too big",
+			req: &Request{
+				InBlob: make([]byte, 4096),
+			},
+			wantErr: "invalid argument",
+		},
+		{
+			name: "privlevel too high",
+			req: &Request{
+				InBlob:    make([]byte, 64),
+				Privilege: &Privilege{Level: 300},
+			},
+			wantErr: "privlevel must be 0-3",
+		},
+		{
+			name:    "missing inblob",
+			req:     &Request{},
+			wantErr: "invalid argument",
+		},
+		{
+			name: "privlevel too low",
+			req: &Request{
+				InBlob:    make([]byte, 64),
+				Privilege: &Privilege{Level: 0},
+			},
+			floor:   1,
+			wantErr: "privlevel 0 cannot be less than 1",
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &faketsm.Client{Subsystems: map[string]configfsi.Client{"report": faketsm.ReportV7(tc.floor)}}
+			resp, err := Get(c, tc.req)
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("Get(%+v) = %+v, %v, want %q", tc.req, resp, err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/testing/mocks.go
+++ b/testing/mocks.go
@@ -139,3 +139,22 @@ func (g *Getter) Get(url string) (map[string][]string, []byte, error) {
 	}
 	return v.Header, v.Body, nil
 }
+
+// TdxQuoteProvider represents a fake quote provider with pre-programmed responses.
+type TdxQuoteProvider struct {
+	isSupported      bool
+	rawQuoteResponse map[[labi.TdReportDataSize]byte][]uint8
+}
+
+// IsSupported checks if mock quote provider is supported.
+func (p *TdxQuoteProvider) IsSupported() error {
+	if p.isSupported {
+		return nil
+	}
+	return fmt.Errorf("configfs not supported")
+}
+
+// GetRawQuote returns pre-programmed response as raw quote.
+func (p *TdxQuoteProvider) GetRawQuote(reportData [64]byte) ([]uint8, error) {
+	return p.rawQuoteResponse[reportData], nil
+}

--- a/testing/test_cases.go
+++ b/testing/test_cases.go
@@ -16,7 +16,6 @@
 package testing
 
 import (
-	_ "embed"
 	labi "github.com/google/go-tdx-guest/client/linuxabi"
 	"github.com/google/go-tdx-guest/testing/testdata"
 )
@@ -50,19 +49,19 @@ var QeIdentityHeader = map[string][]string{
 // TestGetter is a local getter tied to the included sample quote
 var TestGetter = &Getter{
 	Responses: map[string]HTTPResponse{
-		"https://api.trustedservices.intel.com/tdx/certification/v4/qe/identity": HTTPResponse{
+		"https://api.trustedservices.intel.com/tdx/certification/v4/qe/identity": {
 			Header: QeIdentityHeader,
 			Body:   testdata.QeIdentityBody,
 		},
-		"https://api.trustedservices.intel.com/tdx/certification/v4/tcb?fmspc=50806f000000": HTTPResponse{
+		"https://api.trustedservices.intel.com/tdx/certification/v4/tcb?fmspc=50806f000000": {
 			Header: TcbInfoHeader,
 			Body:   testdata.TcbInfoBody,
 		},
-		"https://api.trustedservices.intel.com/sgx/certification/v4/pckcrl?ca=platform&encoding=der": HTTPResponse{
+		"https://api.trustedservices.intel.com/sgx/certification/v4/pckcrl?ca=platform&encoding=der": {
 			Header: PckCrlHeader,
 			Body:   testdata.PckCrlBody,
 		},
-		"https://certificates.trustedservices.intel.com/IntelSGXRootCA.der": HTTPResponse{
+		"https://certificates.trustedservices.intel.com/IntelSGXRootCA.der": {
 			Header: nil,
 			Body:   testdata.RootCrlBody,
 		},

--- a/testing/test_cases.go
+++ b/testing/test_cases.go
@@ -16,6 +16,7 @@
 package testing
 
 import (
+	_ "embed"
 	labi "github.com/google/go-tdx-guest/client/linuxabi"
 	"github.com/google/go-tdx-guest/testing/testdata"
 )
@@ -49,19 +50,19 @@ var QeIdentityHeader = map[string][]string{
 // TestGetter is a local getter tied to the included sample quote
 var TestGetter = &Getter{
 	Responses: map[string]HTTPResponse{
-		"https://api.trustedservices.intel.com/tdx/certification/v4/qe/identity": {
+		"https://api.trustedservices.intel.com/tdx/certification/v4/qe/identity": HTTPResponse{
 			Header: QeIdentityHeader,
 			Body:   testdata.QeIdentityBody,
 		},
-		"https://api.trustedservices.intel.com/tdx/certification/v4/tcb?fmspc=50806f000000": {
+		"https://api.trustedservices.intel.com/tdx/certification/v4/tcb?fmspc=50806f000000": HTTPResponse{
 			Header: TcbInfoHeader,
 			Body:   testdata.TcbInfoBody,
 		},
-		"https://api.trustedservices.intel.com/sgx/certification/v4/pckcrl?ca=platform&encoding=der": {
+		"https://api.trustedservices.intel.com/sgx/certification/v4/pckcrl?ca=platform&encoding=der": HTTPResponse{
 			Header: PckCrlHeader,
 			Body:   testdata.PckCrlBody,
 		},
-		"https://certificates.trustedservices.intel.com/IntelSGXRootCA.der": {
+		"https://certificates.trustedservices.intel.com/IntelSGXRootCA.der": HTTPResponse{
 			Header: nil,
 			Body:   testdata.RootCrlBody,
 		},
@@ -101,6 +102,18 @@ func TestCases() []TestCase {
 			Quote:  testdata.RawQuote,
 		},
 	}
+}
+
+// TcQuoteProvider returns a mock quote provider populated from test cases inputs and expected outputs.
+func TcQuoteProvider(tcs []TestCase) (*TdxQuoteProvider, error) {
+	rawQuoteResponses := map[[labi.TdReportDataSize]byte][]uint8{}
+	for _, tc := range tcs {
+		rawQuoteResponses[tc.Input] = tc.Quote
+	}
+	return &TdxQuoteProvider{
+		isSupported:      true,
+		rawQuoteResponse: rawQuoteResponses,
+	}, nil
 }
 
 // TcDevice returns a mock device populated from test cases inputs and expected outputs.


### PR DESCRIPTION
Added an interface - QuoteProvider - which would act as a wrapper over go-configfs-tsm library to fetch raw byte quote in host images with Unified ABI patch from Intel, otherwise use tdx device driver. 2 new APIs added - GetRawQuoteViaProvider, GetQuoteViaProvider. Updated client unit tests and mocks.

Note:- DO NOT USE these new APIs. These might be updated or removed very soon.