### PR TITLE
Update APIs to be future compatible.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # TDX Guest
 
 
-This project offers libraries for a simple wrapper around the `/dev/tdx-guest`
-device in Linux, as well as a library for attestation verification of
-fundamental components of an attestation quote.
+This project offers libraries for a simple wrapper around quote providing tools
+such as the `go-configfs-tsm` library, or the `/dev/tdx_guest` device in Linux,
+as well as a library for attestation verification of fundamental components of
+an attestation quote.
 
 
 This project is split into two complementary roles. The first role is producing
@@ -19,26 +20,37 @@ This library should be used within the confidential workload to collect an
 attestation quote along with requisite certificates.
 
 
-Your main interactions with it will be to open the device, get an attestation
-quote with your provided 64 bytes of user data (typically a nonce), and then
-close the device. For convenience, the attestation with its associated
-certificates can be collected in a wire-transmittable protocol buffer format.
+Your main interactions with it will be to first get the quote provider, or
+open the device, then get an attestation quote with your provided 64 bytes of
+user data (typically a nonce), and then close the device. For convenience, the
+attestation with its associated certificates can be collected in a
+wire-transmittable protocol buffer format.
+
+
+### `func GetQuoteProvider() (*LinuxConfigFsQuoteProvider, error)`
+
+
+This function creates an instance of a quote provider which uses the go-configfs-tsm
+library to fetch attestation quotes via ConfigFS.
 
 
 ### `func OpenDevice() (*LinuxDevice, error)`
 
 
-This function creates a file descriptor to the `/dev/tdx-guest` device and
+This function creates a file descriptor to the `/dev/tdx_guest` device and
 returns an object that has methods encapsulating commands to the device. When
 done, remember to `Close()` the device.
+Note:- The Device interface is deprecated, and use of quote provider interface
+is recommended for fetching attestation quote.
 
 
-### `func GetQuote(d Device, reportData [64]byte) (*pb.QuoteV4, error)`
+### `func GetQuote(quoteProvider any, reportData [64]byte) (any, error)`
 
 
-This function takes an object implementing the `Device` interface (e.g., a
-`LinuxDevice`) and returns the protocol buffer representation of the attestation
-quote.
+This function takes an object implementing either the `QuoteProvider` interface
+(e.g. `LinuxConfigFsQuoteProvider`), or the `Device` interface (e.g., a `LinuxDevice`)
+along with report data which typically consists of a nonce value.
+It returns the protocol buffer representation of the attestation quote.
 
 
 You can use `GetRawQuote` to get the TDX Quote in byte array format.

--- a/abi/abi.go
+++ b/abi/abi.go
@@ -105,6 +105,7 @@ const (
 	headerQeVendorIDEnd                     = 0x1C
 	headerUserDataStart                     = headerQeVendorIDEnd
 	headerUserDataEnd                       = 0x30
+	intelQuoteV4Version                     = 4
 	tdTeeTcbSvnStart                        = 0x00
 	tdTeeTcbSvnEnd                          = 0x10
 	tdMrSeamStart                           = tdTeeTcbSvnEnd
@@ -180,29 +181,32 @@ const (
 )
 
 var (
-	// ErrQuoteV4Nil error returned when QuoteV4 is empty
-	ErrQuoteV4Nil = errors.New("QuoteV4 is empty")
+	// ErrQuoteNil error returned when Quote is nil
+	ErrQuoteNil = errors.New("Quote is nil")
 
-	// ErrQuoteV4AuthDataNil error returned when QuoteV4 Auth Data is empty
-	ErrQuoteV4AuthDataNil = errors.New("QuoteV4 authData is empty")
+	// ErrQuoteV4Nil error returned when QuoteV4 is nil
+	ErrQuoteV4Nil = errors.New("QuoteV4 is nil")
 
-	// ErrCertificationDataNil error returned when Certification Data is empty
-	ErrCertificationDataNil = errors.New("certification data is empty")
+	// ErrQuoteV4AuthDataNil error returned when QuoteV4 Auth Data is nil
+	ErrQuoteV4AuthDataNil = errors.New("QuoteV4 authData is nil")
 
-	// ErrQeReportCertificationDataNil error returned when QE report certification data is empty
-	ErrQeReportCertificationDataNil = errors.New("QE Report certification data is empty")
+	// ErrCertificationDataNil error returned when Certification Data is nil
+	ErrCertificationDataNil = errors.New("certification data is nil")
 
-	// ErrQeAuthDataNil error returned when QE Auth Data is empty
-	ErrQeAuthDataNil = errors.New("QE AuthData is empty")
+	// ErrQeReportCertificationDataNil error returned when QE report certification data is nil
+	ErrQeReportCertificationDataNil = errors.New("QE Report certification data is nil")
 
-	// ErrQeReportNil error returned when QE Report is empty
-	ErrQeReportNil = errors.New("QE Report is empty")
+	// ErrQeAuthDataNil error returned when QE Auth Data is nil
+	ErrQeAuthDataNil = errors.New("QE AuthData is nil")
 
-	// ErrPckCertChainNil error returned when PCK Certificate Chain is empty
-	ErrPckCertChainNil = errors.New("PCK certificate chain is empty")
+	// ErrQeReportNil error returned when QE Report is nil
+	ErrQeReportNil = errors.New("QE Report is nil")
 
-	// ErrTDQuoteBodyNil error returned when TD quote body is empty
-	ErrTDQuoteBodyNil = errors.New("TD quote body is empty")
+	// ErrPckCertChainNil error returned when PCK Certificate Chain is nil
+	ErrPckCertChainNil = errors.New("PCK certificate chain is nil")
+
+	// ErrTDQuoteBodyNil error returned when TD quote body is nil
+	ErrTDQuoteBodyNil = errors.New("TD quote body is nil")
 
 	// ErrTeeType error returned when TEE type is not TDX
 	ErrTeeType = errors.New("TEE type is not TDX")
@@ -210,8 +214,8 @@ var (
 	// ErrAttestationKeyType error returned when attestation key is not of expected type
 	ErrAttestationKeyType = errors.New("attestation key type not supported")
 
-	// ErrHeaderNil error returned when header is empty
-	ErrHeaderNil = errors.New("header is empty")
+	// ErrHeaderNil error returned when header is nil
+	ErrHeaderNil = errors.New("header is nil")
 )
 
 func clone(b []byte) []byte {
@@ -220,8 +224,27 @@ func clone(b []byte) []byte {
 	return result
 }
 
-// QuoteToProto creates a pb.QuoteV4 from the Intel's attestation quote byte array in Intel's ABI format.
-func QuoteToProto(b []uint8) (*pb.QuoteV4, error) {
+// determineQuoteFormat returns the quote format version from the header.
+func determineQuoteFormat(b []uint8) uint32 {
+	data := clone(b)
+	header := &pb.Header{}
+	header.Version = uint32(binary.LittleEndian.Uint16(data[headerVersionStart:headerVersionEnd]))
+	return header.Version
+}
+
+// QuoteToProto creates a Quote from the Intel's attestation quote byte array in Intel's ABI format.
+// Supported quote formats - QuoteV4.
+func QuoteToProto(b []uint8) (any, error) {
+	switch determineQuoteFormat(b) {
+	case intelQuoteV4Version:
+		return quoteToProtoV4(b)
+	default:
+		return nil, fmt.Errorf("Quote format not supported")
+	}
+}
+
+// quoteToProtoV4 creates a pb.QuoteV4 from the Intel's attestation quote byte array in Intel's ABI format.
+func quoteToProtoV4(b []uint8) (*pb.QuoteV4, error) {
 	data := clone(b) // Created an independent copy to make the interface less error-prone
 	if len(data) < QuoteMinSize {
 		return nil, fmt.Errorf("raw quote size is 0x%x, a TDX quote should have size a minimum size of 0x%x", len(data), QuoteMinSize)
@@ -832,11 +855,22 @@ func signedDataToAbiBytes(signedData *pb.Ecdsa256BitQuoteV4AuthData) ([]byte, er
 	return data, nil
 }
 
-// QuoteToAbiBytes translates the QuoteV4 back into its little-endian ABI format
-func QuoteToAbiBytes(quote *pb.QuoteV4) ([]byte, error) {
+// QuoteToAbiBytes translates the Quote back into its little-endian ABI format.
+// Supported quote formats - QuoteV4.
+func QuoteToAbiBytes(quote any) ([]byte, error) {
 	if quote == nil {
-		return nil, ErrQuoteV4Nil
+		return nil, ErrQuoteNil
 	}
+	switch q := quote.(type) {
+	case *pb.QuoteV4:
+		return quoteToAbiBytesV4(q)
+	default:
+		return nil, fmt.Errorf("unsupported quote type: %T", quote)
+	}
+}
+
+// quoteToAbiBytesV4 translates the QuoteV4 back into its little-endian ABI format
+func quoteToAbiBytesV4(quote *pb.QuoteV4) ([]byte, error) {
 	if err := CheckQuoteV4(quote); err != nil {
 		return nil, fmt.Errorf("QuoteV4 invalid: %v", err)
 	}

--- a/abi/abi.go
+++ b/abi/abi.go
@@ -182,7 +182,7 @@ const (
 
 var (
 	// ErrQuoteNil error returned when Quote is nil
-	ErrQuoteNil = errors.New("Quote is nil")
+	ErrQuoteNil = errors.New("quote is nil")
 
 	// ErrQuoteV4Nil error returned when QuoteV4 is nil
 	ErrQuoteV4Nil = errors.New("QuoteV4 is nil")
@@ -239,7 +239,7 @@ func QuoteToProto(b []uint8) (any, error) {
 	case intelQuoteV4Version:
 		return quoteToProtoV4(b)
 	default:
-		return nil, fmt.Errorf("Quote format not supported")
+		return nil, fmt.Errorf("quote format not supported")
 	}
 }
 

--- a/abi/abi_test.go
+++ b/abi/abi_test.go
@@ -45,7 +45,7 @@ func TestQuoteToAbiBytes(t *testing.T) {
 
 func TestNilToAbiBytesConversions(t *testing.T) {
 
-	if _, err := QuoteToAbiBytes(nil); err != ErrQuoteV4Nil {
+	if _, err := QuoteToAbiBytes(nil); err != ErrQuoteNil {
 		t.Error(err)
 	}
 	if _, err := signedDataToAbiBytes(nil); err != ErrQuoteV4AuthDataNil {
@@ -76,12 +76,12 @@ func TestNilToAbiBytesConversions(t *testing.T) {
 
 func TestInvalidConversionsToAbiBytes(t *testing.T) {
 	expectedErrors := []string{
-		"QuoteV4 invalid: QuoteV4 Header error: header is empty",
+		"QuoteV4 invalid: QuoteV4 Header error: header is nil",
 		"QuoteV4 AuthData invalid: signature size is 0 bytes. Expected 64 bytes",
 		"certification data invalid: certification data type invalid, got 0, expected 6",
 		"certification data invalid: certification data type invalid, got 7, expected 6",
-		"certification data invalid: QE Report certification data error: QE Report certification data is empty",
-		"QE Report certification data invalid: QE Report error: QE Report is empty",
+		"certification data invalid: QE Report certification data error: QE Report certification data is nil",
+		"QE Report certification data invalid: QE Report error: QE Report is nil",
 		"QE AuthData invalid: parsed data size is 0 bytes. Expected 1 bytes",
 		"PCK certificate chain data invalid: PCK certificate chain data type invalid, got 0, expected 5",
 		"PCK certificate chain data invalid: PCK certificate chain data type invalid, got 7, expected 5",

--- a/abi/abi_test.go
+++ b/abi/abi_test.go
@@ -23,7 +23,14 @@ import (
 )
 
 func TestQuoteToProto(t *testing.T) {
-	_, err := QuoteToProto(test.RawQuote)
+	expectedError := "unable to determine quote format since bytes length is less than 2 bytes"
+	var emptyRawQuote []uint8
+	_, err := QuoteToProto(emptyRawQuote)
+	if err == nil || err.Error() != expectedError {
+		t.Errorf("error found: %v, want error: %s", err, expectedError)
+	}
+
+	_, err = QuoteToProto(test.RawQuote)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -22,13 +22,14 @@ import (
 
 	"github.com/google/go-tdx-guest/abi"
 	labi "github.com/google/go-tdx-guest/client/linuxabi"
-	pb "github.com/google/go-tdx-guest/proto/tdx"
 )
 
 var tdxGuestPath = flag.String("tdx_guest_device_path", "default",
 	"Path to TDX guest device. If \"default\", uses platform default or a fake if testing.")
 
 // Device encapsulates the possible commands to the TDX guest device.
+// Deprecated: The Device interface is deprecated, and use of quote provider interface is
+// recommended for fetching attestation quote.
 type Device interface {
 	Open(path string) error
 	Close() error
@@ -60,11 +61,24 @@ func getReport(d Device, reportData [64]byte) ([]uint8, error) {
 	return tdxReportReq.TdReport[:], nil
 }
 
-// GetRawQuote call getReport for report and convert it to quote using an ioctl call.
-func GetRawQuote(d Device, reportData [64]byte) ([]uint8, uint32, error) {
+// GetRawQuote uses Quote provider or Device(deprecated) to get the quote in byte array.
+func GetRawQuote(quoteProvider any, reportData [64]byte) ([]uint8, error) {
+	switch qp := quoteProvider.(type) {
+	case Device:
+		return getRawQuoteViaDevice(qp, reportData)
+	case QuoteProvider:
+		return getRawQuoteViaProvider(qp, reportData)
+	default:
+		return nil, fmt.Errorf("unsupported quote provider type: %T", quoteProvider)
+	}
+}
+
+// getRawQuoteViaDevice uses TDX device driver to call getReport for report and convert it to
+// quote using an ioctl call.
+func getRawQuoteViaDevice(d Device, reportData [64]byte) ([]uint8, error) {
 	tdReport, err := getReport(d, reportData)
 	if err != nil {
-		return nil, 0, err
+		return nil, err
 	}
 	tdxHdr := &labi.TdxQuoteHdr{
 		Status:  0,
@@ -79,58 +93,68 @@ func GetRawQuote(d Device, reportData [64]byte) ([]uint8, uint32, error) {
 	}
 	result, err := d.Ioctl(labi.IocTdxGetQuote, &tdxReq)
 	if err != nil {
-		return nil, 0, err
+		return nil, err
 	}
 	if result != uintptr(labi.TdxAttestSuccess) {
-		return nil, 0, fmt.Errorf("unable to get the quote")
+		return nil, fmt.Errorf("unable to get the quote")
 	}
 	if tdxHdr.Status != 0 {
 		if labi.GetQuoteInFlight == tdxHdr.Status {
-			return nil, 0, fmt.Errorf("the device driver return busy")
+			return nil, fmt.Errorf("the device driver return busy")
 		} else if labi.GetQuoteServiceUnavailable == tdxHdr.Status {
-			return nil, 0, fmt.Errorf("request feature is not supported")
+			return nil, fmt.Errorf("request feature is not supported")
 		} else if tdxHdr.OutLen == 0 || tdxHdr.OutLen > labi.ReqBufSize {
-			return nil, 0, fmt.Errorf("invalid Quote size: %v. It must be > 0 and <= : %v", tdxHdr.OutLen, labi.ReqBufSize)
+			return nil, fmt.Errorf("invalid Quote size: %v. It must be > 0 and <= : %v", tdxHdr.OutLen, labi.ReqBufSize)
 		}
 
-		return nil, 0, fmt.Errorf("unexpected error: %v", tdxHdr.Status)
+		return nil, fmt.Errorf("unexpected error: %v", tdxHdr.Status)
 	}
 
-	return tdxHdr.Data[:tdxHdr.OutLen], tdxHdr.OutLen, nil
+	return tdxHdr.Data[:tdxHdr.OutLen], nil
 }
 
-// GetQuote call GetRawQuote to get the quote in byte array and convert it into proto.
-func GetQuote(d Device, reportData [64]byte) (*pb.QuoteV4, error) {
-	quotebytes, size, err := GetRawQuote(d, reportData)
-	if err != nil {
-		return nil, err
-	}
-	if len(quotebytes) > int(size) {
-		quotebytes = quotebytes[:size]
-	}
-	return convertRawQuoteToProto(quotebytes)
-}
-
-// GetRawQuoteViaProvider use QuoteProvider to fetch quote in byte array format.
-func GetRawQuoteViaProvider(qp QuoteProvider, reportData [64]byte) ([]uint8, error) {
+// getRawQuoteViaProvider use QuoteProvider to fetch quote in byte array format.
+func getRawQuoteViaProvider(qp QuoteProvider, reportData [64]byte) ([]uint8, error) {
 	if err := qp.IsSupported(); err == nil {
-		return qp.GetRawQuote(reportData)
+		quote, err := qp.GetRawQuote(reportData)
+		return quote, err
 	}
 	return fallbackToDeviceForRawQuote(reportData)
 }
 
-// GetQuoteViaProvider use QuoteProvider to fetch attestation quote.
-func GetQuoteViaProvider(qp QuoteProvider, reportData [64]byte) (*pb.QuoteV4, error) {
-	bytes, err := GetRawQuoteViaProvider(qp, reportData)
+// GetQuote uses Quote provider or Device(deprecated) to get the quote in byte array and convert it
+// into proto.
+// Supported quote formats - QuoteV4.
+func GetQuote(quoteProvider any, reportData [64]byte) (any, error) {
+	switch qp := quoteProvider.(type) {
+	case Device:
+		return getQuoteViaDevice(qp, reportData)
+	case QuoteProvider:
+		return getQuoteViaProvider(qp, reportData)
+	}
+	return nil, fmt.Errorf("unsupported quote provider type: %T", quoteProvider)
+}
+
+// getQuoteViaDevice call GetRawQuote to get the quote in byte array and convert it into proto.
+func getQuoteViaDevice(d Device, reportData [64]byte) (any, error) {
+	quotebytes, err := getRawQuoteViaDevice(d, reportData)
 	if err != nil {
 		return nil, err
 	}
-	return convertRawQuoteToProto(bytes)
+	quote, err := abi.QuoteToProto(quotebytes)
+	if err != nil {
+		return nil, err
+	}
+	return quote, nil
 }
 
-// convertRawQuoteToProto converts raw quote in byte array format to proto.
-func convertRawQuoteToProto(rawQuote []byte) (*pb.QuoteV4, error) {
-	quote, err := abi.QuoteToProto(rawQuote)
+// getQuoteViaProvider use QuoteProvider to fetch attestation quote.
+func getQuoteViaProvider(qp QuoteProvider, reportData [64]byte) (any, error) {
+	bytes, err := getRawQuoteViaProvider(qp, reportData)
+	if err != nil {
+		return nil, err
+	}
+	quote, err := abi.QuoteToProto(bytes)
 	if err != nil {
 		return nil, err
 	}
@@ -142,9 +166,9 @@ func fallbackToDeviceForRawQuote(reportData [64]byte) ([]uint8, error) {
 	// Fall back to TDX device driver.
 	device, err := OpenDevice()
 	if err != nil {
-		return nil, fmt.Errorf("neither tdx device, nor configFs is available to fetch attestation quote")
+		return nil, fmt.Errorf("neither TDX device, nor ConfigFs is available to fetch attestation quote")
 	}
-	bytes, _, err := GetRawQuote(device, reportData)
+	bytes, err := getRawQuoteViaDevice(device, reportData)
 	device.Close()
 	return bytes, err
 }

--- a/client/client.go
+++ b/client/client.go
@@ -126,35 +126,11 @@ func getRawQuoteViaProvider(qp QuoteProvider, reportData [64]byte) ([]uint8, err
 // into proto.
 // Supported quote formats - QuoteV4.
 func GetQuote(quoteProvider any, reportData [64]byte) (any, error) {
-	switch qp := quoteProvider.(type) {
-	case Device:
-		return getQuoteViaDevice(qp, reportData)
-	case QuoteProvider:
-		return getQuoteViaProvider(qp, reportData)
-	}
-	return nil, fmt.Errorf("unsupported quote provider type: %T", quoteProvider)
-}
-
-// getQuoteViaDevice call GetRawQuote to get the quote in byte array and convert it into proto.
-func getQuoteViaDevice(d Device, reportData [64]byte) (any, error) {
-	quotebytes, err := getRawQuoteViaDevice(d, reportData)
+	quotebytes, err := GetRawQuote(quoteProvider, reportData)
 	if err != nil {
 		return nil, err
 	}
 	quote, err := abi.QuoteToProto(quotebytes)
-	if err != nil {
-		return nil, err
-	}
-	return quote, nil
-}
-
-// getQuoteViaProvider use QuoteProvider to fetch attestation quote.
-func getQuoteViaProvider(qp QuoteProvider, reportData [64]byte) (any, error) {
-	bytes, err := getRawQuoteViaProvider(qp, reportData)
-	if err != nil {
-		return nil, err
-	}
-	quote, err := abi.QuoteToProto(bytes)
 	if err != nil {
 		return nil, err
 	}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -84,7 +84,7 @@ func TestGetRawQuote(t *testing.T) {
 	devMu.Do(initialize)
 	for _, tc := range test.TestCases() {
 		t.Run(tc.Name, func(t *testing.T) {
-			got, _, err := GetRawQuote(device, tc.Input)
+			got, err := GetRawQuote(device, tc.Input)
 			if !test.Match(err, tc.WantErr) {
 				t.Fatalf("GetRawQuote(device, %v) = %v, %v. Want err: %q", tc.Input, got, err, tc.WantErr)
 			}
@@ -121,7 +121,7 @@ func TestGetRawQuoteViaProvider(t *testing.T) {
 	devMu.Do(initialize)
 	for _, tc := range test.TestCases() {
 		t.Run(tc.Name, func(t *testing.T) {
-			got, err := GetRawQuoteViaProvider(quoteProvider, tc.Input)
+			got, err := GetRawQuote(quoteProvider, tc.Input)
 			if !test.Match(err, tc.WantErr) {
 				t.Fatalf("GetRawQuoteViaProvider(quoteProvider, %v) = %v, %v. Want err: %q", tc.Input, got, err, tc.WantErr)
 			}
@@ -138,7 +138,7 @@ func TestGetQuoteViaProvider(t *testing.T) {
 	devMu.Do(initialize)
 	for _, tc := range test.TestCases() {
 		t.Run(tc.Name, func(t *testing.T) {
-			got, err := GetQuoteViaProvider(quoteProvider, tc.Input)
+			got, err := GetQuote(quoteProvider, tc.Input)
 			if !test.Match(err, tc.WantErr) {
 				t.Fatalf("Expected %v got err: %v", err, tc.WantErr)
 			}

--- a/testing/client/client.go
+++ b/testing/client/client.go
@@ -41,3 +41,13 @@ func GetTdxGuest(tcs []test.TestCase, tb testing.TB) client.Device {
 	}
 	return client
 }
+
+// GetMockTdxQuoteProvider is a testing helper function that produces a fake TDX quote provider.
+func GetMockTdxQuoteProvider(tcs []test.TestCase, tb testing.TB) client.QuoteProvider {
+	tb.Helper()
+	tdxTestQuoteProvider, err := test.TcQuoteProvider(tcs)
+	if err != nil {
+		tb.Fatalf("Failed to create test quote provider: %v", err)
+	}
+	return tdxTestQuoteProvider
+}

--- a/tools/attest/attest.go
+++ b/tools/attest/attest.go
@@ -76,7 +76,7 @@ func marshalAndWriteBytes(quote any, out io.Writer) error {
 		out.Write(bytes)
 		return nil
 	default:
-		return fmt.Errorf("Unsupported quote type: %T", quote)
+		return fmt.Errorf("unsupported quote type: %T", quote)
 	}
 }
 

--- a/tools/check/check.go
+++ b/tools/check/check.go
@@ -114,7 +114,7 @@ var (
 	}
 )
 
-func parseQuoteBytes(b []byte) (*pb.QuoteV4, error) {
+func parseQuoteBytes(b []byte) (any, error) {
 	quote, err := abi.QuoteToProto(b)
 	if err != nil {
 		return nil, fmt.Errorf("could not parse the TDX Quote from %q: %v", *infile, err)
@@ -123,7 +123,7 @@ func parseQuoteBytes(b []byte) (*pb.QuoteV4, error) {
 	return quote, nil
 }
 
-func parseQuote(b []byte) (*pb.QuoteV4, error) {
+func parseQuote(b []byte) (any, error) {
 	switch *inform {
 	case "bin":
 		return parseQuoteBytes(b)
@@ -164,7 +164,7 @@ func parseUint(p string, bits int) (uint64, error) {
 	return info64, nil
 }
 
-func readQuote() (*pb.QuoteV4, error) {
+func readQuote() (any, error) {
 	var in io.Reader
 	var f *os.File
 	if *infile == "-" {

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -301,12 +301,23 @@ func validateTdAttributes(value []byte, fixed1, fixed0 uint64) error {
 	return nil
 }
 
-// TdxQuote validates fields of the protobuf representation of an attestation Quote against
-// expectations. Does not check the attestation certificates or signature.
-func TdxQuote(quote *pb.QuoteV4, options *Options) error {
+// TdxQuote validates fields of the protobuf representation of an attestation Quote
+// against expectations depending on supported quote formats - QuoteV4.
+func TdxQuote(quote any, options *Options) error {
 	if options == nil {
 		return vr.ErrOptionsNil
 	}
+	switch q := quote.(type) {
+	case *pb.QuoteV4:
+		return tdxQuoteV4(q, options)
+	default:
+		return fmt.Errorf("Unsupported quote type: %T", quote)
+	}
+}
+
+// tdxQuoteV4 validates QuoteV4 fields of the protobuf representation of an attestation Quote
+// against expectations. Does not check the attestation certificates or signature.
+func tdxQuoteV4(quote *pb.QuoteV4, options *Options) error {
 	if err := abi.CheckQuoteV4(quote); err != nil {
 		return fmt.Errorf("QuoteV4 invalid: %v", err)
 	}

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -311,7 +311,7 @@ func TdxQuote(quote any, options *Options) error {
 	case *pb.QuoteV4:
 		return tdxQuoteV4(q, options)
 	default:
-		return fmt.Errorf("Unsupported quote type: %T", quote)
+		return fmt.Errorf("unsupported quote type: %T", quote)
 	}
 }
 

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -303,6 +303,7 @@ func validateTdAttributes(value []byte, fixed1, fixed0 uint64) error {
 
 // TdxQuote validates fields of the protobuf representation of an attestation Quote
 // against expectations depending on supported quote formats - QuoteV4.
+// Does not check the attestation certificates or signature.
 func TdxQuote(quote any, options *Options) error {
 	if options == nil {
 		return vr.ErrOptionsNil

--- a/validate/validate_test.go
+++ b/validate/validate_test.go
@@ -90,15 +90,19 @@ func TestTdxQuote(t *testing.T) {
 
 	nonce12345 := mknonce([]byte{1, 2, 3, 4, 5})
 
-	quoteFn := func(nonce []byte) *pb.QuoteV4 {
+	quoteFn := func(nonce []byte) any {
 		quote, err := abi.QuoteToProto(testdata.RawQuote)
 		if err != nil {
 			t.Fatal(err)
 		}
 		data := make([]byte, abi.ReportDataSize)
 		copy(data, nonce[:])
-		quote.TdQuoteBody.ReportData = data
-
+		switch q := quote.(type) {
+		case *pb.QuoteV4:
+			q.TdQuoteBody.ReportData = data
+		default:
+			t.Fatal("unsupported quote type")
+		}
 		return quote
 	}
 	quoteSample := quoteFn(reportData)
@@ -106,7 +110,7 @@ func TestTdxQuote(t *testing.T) {
 
 	type testCase struct {
 		name    string
-		quote   *pb.QuoteV4
+		quote   any
 		opts    *Options
 		wantErr string
 	}

--- a/verify/verify.go
+++ b/verify/verify.go
@@ -1236,7 +1236,7 @@ func verifyEvidenceV4(quote *pb.QuoteV4, options *Options) error {
 
 // TdxQuote verifies the protobuf representation of an attestation quote's signature
 // based on the quote's SignatureAlgo, provided the certificate chain is valid for
-// formats - QuoteV4, QuoteV5 etc.
+// formats - QuoteV4.
 func TdxQuote(quote any, options *Options) error {
 	if options == nil {
 		return ErrOptionsNil

--- a/verify/verify.go
+++ b/verify/verify.go
@@ -608,7 +608,7 @@ func extractChainFromQuote(quote any) (*PCKCertificateChain, error) {
 	case *pb.QuoteV4:
 		return extractChainFromQuoteV4(q)
 	default:
-		return nil, fmt.Errorf("Unsupported quote type: %T", quote)
+		return nil, fmt.Errorf("unsupported quote type: %T", quote)
 	}
 }
 

--- a/verify/verify_test.go
+++ b/verify/verify_test.go
@@ -282,7 +282,7 @@ func TestNegativeVerification(t *testing.T) {
 			name:        "Version byte Changed",
 			changeIndex: 0x00,
 			changeValue: 3,
-			wantErr:     "could not convert raw bytes to QuoteV4: Quote format not supported",
+			wantErr:     "could not convert raw bytes to QuoteV4: quote format not supported",
 		},
 		{
 			name:        "Signed data size byte Changed",


### PR DESCRIPTION
The go-tdx-guest tool is tightly dependent on TDX quote V4 format and soon it would be moving to QuoteV5 format. So updating current APIs to be generic, and support any Quote format without needing changes in these APIs from our customers. Recently added APIs - GetQuoteViaProvider() & GetRawQuoteViaProvider() - have been removed and the logic has been combined with same old APIs - GetRawQuote() & GetQuote() - with the help of ‘any’ interface. Most of the unit tests use QuoteV4 for testing so when the tool moves to other quote formats, then these unit tests would be updated holistically. go-tpm-tools need a type-cast to QuoteV4 in its attest package.

Breaking changes in go-tdx-guest :-

abi

QuoteToAbiBytes(quote any) ([]byte, error) : If a nil quote is provided then returned error would be ErrQuoteNil and not ErrQuoteV4Nil. If a customer is doing some error handling specific to this error then it needs to be modified.
client

GetRawQuote(quoteProvider any, reportData [64]byte) ([]uint8, error) : Removed the size/length from the return response. Error message should be sufficient for handling.
GetQuote(quoteProvider any, reportData [64]byte) (any, error) : It can now take in any input - device or quote provider - to fetch attestation quote and return any valid TDX quote format. A customer would be required to type cast it to V4, if directly using go-tdx-guest’s client package to fetch quote and perform verification without using go-tdx-guest’s tools.