### PR TITLE
Allow null byte in PCK Certificate Chain data

### DIFF
--- a/verify/verify.go
+++ b/verify/verify.go
@@ -643,7 +643,8 @@ func extractChainFromQuoteV4(quote *pb.QuoteV4) (*PCKCertificateChain, error) {
 		return nil, ErrPCKCertChainInvalid
 	}
 
-	if len(rem) != 0 && !bytes.Equal(rem, []byte{0x00}) { // The final byte of the certificate chain can be a null byte.
+	// The final byte of the certificate chain can be a null byte.
+	if len(rem) != 0 && !bytes.Equal(rem, []byte{0x00}) {
 		return nil, fmt.Errorf("unexpected trailing bytes were found in PCK Certificate Chain: %d byte(s)", len(rem))
 	}
 

--- a/verify/verify_test.go
+++ b/verify/verify_test.go
@@ -60,13 +60,14 @@ func TestParsePckChain(t *testing.T) {
 	if _, err := extractChainFromQuote(quote); err != nil {
 		t.Fatal(err)
 	}
+
 	certChain := quote.(*pb.QuoteV4).SignedData.CertificationData.QeReportCertificationData.PckCertificateChainData.PckCertChain
 	certChain = append(certChain, 0)
 	quote.(*pb.QuoteV4).SignedData.CertificationData.QeReportCertificationData.PckCertificateChainData.PckCertChain = certChain
-
 	if _, err := extractChainFromQuote(quote); err != nil {
 		t.Error(err)
 	}
+
 	certChain[len(certChain)-1] = 1
 	quote.(*pb.QuoteV4).SignedData.CertificationData.QeReportCertificationData.PckCertificateChainData.PckCertChain = certChain
 	if _, err := extractChainFromQuote(quote); err == nil {

--- a/verify/verify_test.go
+++ b/verify/verify_test.go
@@ -60,6 +60,18 @@ func TestParsePckChain(t *testing.T) {
 	if _, err := extractChainFromQuote(quote); err != nil {
 		t.Fatal(err)
 	}
+	certChain := quote.(*pb.QuoteV4).SignedData.CertificationData.QeReportCertificationData.PckCertificateChainData.PckCertChain
+	certChain = append(certChain, 0)
+	quote.(*pb.QuoteV4).SignedData.CertificationData.QeReportCertificationData.PckCertificateChainData.PckCertChain = certChain
+
+	if _, err := extractChainFromQuote(quote); err != nil {
+		t.Error(err)
+	}
+	certChain[len(certChain)-1] = 1
+	quote.(*pb.QuoteV4).SignedData.CertificationData.QeReportCertificationData.PckCertificateChainData.PckCertChain = certChain
+	if _, err := extractChainFromQuote(quote); err == nil {
+		t.Error("Expected error but got none")
+	}
 }
 
 func TestPckCertificateExtensions(t *testing.T) {


### PR DESCRIPTION
The PCK certificate chain may include a null byte as its final byte. A check has been added for this, along with a corresponding test case to validate it.