### PR TITLE
Add RTMR extend package.

### DIFF
--- a/rtmr/extend/extend.go
+++ b/rtmr/extend/extend.go
@@ -1,0 +1,199 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extend
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/sha512" // Registrer SHA384 and SHA512
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/google/go-configfs-tsm/configfs/configfsi"
+	"github.com/google/go-configfs-tsm/configfs/linuxtsm"
+	"github.com/google/logger"
+)
+
+const (
+	RtmrSubsystem = "rtmrs"
+	TsmRtmrPrefix = configfsi.TsmPrefix + "/" + RtmrSubsystem
+	TsmRtmrDigest = "digest"
+	TsmPathIndex  = "index"
+	TsmPathTcgMap = "tcg_map"
+)
+
+// RtmrExtend is a struct that represents a rtmr entry in the configfs.
+type RtmrExtend struct {
+	RtmrIndex int
+	entry     *configfsi.TsmPath
+	client    configfsi.Client
+}
+
+// Remove the null bytes from the c-string
+func convertCstring(b []byte) string {
+	return string(bytes.Trim(b, "\x00"))
+}
+
+func (r *RtmrExtend) attribute(subtree string) string {
+	a := *r.entry
+	a.Attribute = subtree
+	return a.String()
+}
+
+// ExtendDigest extends the measurement to the rtmr with the given hash.
+func (r *RtmrExtend) ExtendDigest(hash []byte) error {
+	if (r.RtmrIndex != 2) && (r.RtmrIndex != 3) {
+		return fmt.Errorf("invalid rtmr index %d, userspace can only extend to rtmr2 or rtmr3", r.RtmrIndex)
+	}
+	if err := r.client.WriteFile(r.attribute(TsmRtmrDigest), hash); err != nil {
+		return fmt.Errorf("could not write report %s: %v", TsmPathIndex, err)
+	}
+	return nil
+}
+
+// SetRtmrIndex sets a configfs rtmr entry to the given index.
+// It reports an error if the index cannot be written or the rtmr_tcg map does not match.
+func (r *RtmrExtend) SetRtmrIndex() error {
+	indexBytes := []byte(strconv.Itoa(r.RtmrIndex)) // Convert index to []byte
+	indexPath := r.attribute(TsmPathIndex)
+	if err := r.client.WriteFile(indexPath, indexBytes); err != nil {
+		return fmt.Errorf("could not write index %s: %v", indexPath, err)
+	}
+	if err := r.ValidateRtmrIndex(); err != nil {
+		return fmt.Errorf("the tcg_map is invalid %s: %v", indexPath, err)
+	}
+	return nil
+}
+
+// ValidateRtmrIndex checks if the rtmr to PCR map is valid.
+// It returns an error if the rtmr_tcg map does not match the expected value.
+func (r *RtmrExtend) ValidateRtmrIndex() error {
+	if (r.client == nil) || (r.entry == nil) {
+		return fmt.Errorf("RtmrExtend is not initialized")
+	}
+	data, err := r.client.ReadFile(r.attribute(TsmPathTcgMap))
+	if err != nil {
+		return fmt.Errorf("could not read  %s: %v", TsmPathTcgMap, err)
+	}
+	var rtmrPcrMaps = map[int]string{
+		0: "1,7\n",
+		1: "2-6\n",
+		2: "8-15\n",
+		3: "\n",
+	}
+
+	inputMap := convertCstring(data)
+	if inputMap != rtmrPcrMaps[r.RtmrIndex] {
+		return fmt.Errorf("tcg map error. expect:%s get:%s", rtmrPcrMaps[r.RtmrIndex], string(data))
+	}
+	return nil
+}
+
+// SearchRtmrInterface searches for an rtmr entry in the configfs.
+func SearchRtmrInterface(client configfsi.Client, index int) (*RtmrExtend, error) {
+	root := TsmRtmrPrefix
+	out := RtmrExtend{}
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() {
+			p, err := configfsi.ParseTsmPath(path)
+			if err != nil {
+				return err
+			}
+			r := RtmrExtend{
+				RtmrIndex: index,
+				entry:     &configfsi.TsmPath{Subsystem: RtmrSubsystem, Entry: p.Entry},
+				client:    client,
+			}
+			if r.ValidateRtmrIndex() == nil {
+				out = r
+				return nil
+			}
+		}
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+	if out.ValidateRtmrIndex() != nil {
+		return nil, fmt.Errorf("could not find rtmr entry in configfs: %v", err)
+	}
+
+	return &out, nil
+}
+
+// CreateRtmrInterface creates a new rtmr entry in the configfs.
+func CreateRtmrInterface(client configfsi.Client, index int) (r *RtmrExtend, err error) {
+	entryPath, err := client.MkdirTemp(TsmRtmrPrefix, fmt.Sprintf("rtmr%d-", index))
+	if err != nil {
+		return nil, fmt.Errorf("could not create rtmr entry in configfs: %v", err)
+	}
+	p, _ := configfsi.ParseTsmPath(entryPath)
+
+	r = &RtmrExtend{
+		RtmrIndex: index,
+		entry:     &configfsi.TsmPath{Subsystem: RtmrSubsystem, Entry: p.Entry},
+		client:    client,
+	}
+
+	if err := r.SetRtmrIndex(); err != nil {
+		return nil, fmt.Errorf("could not set rtmr index %d: %v", index, err)
+	}
+	return r, nil
+}
+
+// ExtendtoRtmrClient extends the measurement to the rtmr with the given client.
+func ExtendtoRtmrClient(client configfsi.Client, rtmr int, hashAlgo crypto.Hash, content []byte) error {
+	if hashAlgo != crypto.SHA384 {
+		return fmt.Errorf("unsupported hash algorithm %v", hashAlgo)
+	}
+	if len(content) == 0 {
+		return fmt.Errorf("input event log is empty")
+	}
+	if rtmr < 0 || rtmr > 3 {
+		return fmt.Errorf("invalid rtmr index %d. Index can only be 0-3", rtmr)
+	}
+
+	r, err := SearchRtmrInterface(client, rtmr)
+	if err != nil {
+		logger.V(2).Infof("Could not find rtmr entry in configfs. error: %v", err)
+		logger.V(1).Info("Creating new rtmr entry in configfs.")
+		r, err = CreateRtmrInterface(client, rtmr)
+		if err != nil {
+			return err
+		}
+	} else {
+		logger.V(1).Info("Found existing rtmr entry in configfs.")
+	}
+
+	hash := sha512.Sum384(content)
+	err = r.ExtendDigest(hash[:])
+	return err
+}
+
+// ExtendtoRtmr extends the measurement to the rtmr with the given hash algorithm and content.
+func ExtendtoRtmr(rtmr int, hashAlgo crypto.Hash, content []byte) error {
+	var err error
+	client, err := linuxtsm.MakeClient()
+	if err != nil {
+		return err
+	}
+	return ExtendtoRtmrClient(client, rtmr, hashAlgo, content)
+}

--- a/rtmr/extend/extend_test.go
+++ b/rtmr/extend/extend_test.go
@@ -1,0 +1,127 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extend
+
+import (
+	"crypto"
+	"fmt"
+	"path"
+	"strconv"
+	"testing"
+
+	"github.com/google/go-configfs-tsm/configfs/configfsi"
+)
+
+type RtmtFakeSubsystem struct {
+	RtmrIndex int
+}
+
+func (r *RtmtFakeSubsystem) RemoveAll(name string) error {
+	p, err := configfsi.ParseTsmPath(name)
+	if err != nil {
+		return fmt.Errorf("RemoveAll: Error %v", err)
+	}
+	if p.Attribute != "" || p.Entry == "" || p.Subsystem != RtmrSubsystem {
+		return fmt.Errorf("RemoveAll: expected RTMR subsystem. Subsystem: %q Entry %q Attribute %q", p.Subsystem, p.Entry, p.Attribute)
+	}
+	return nil
+}
+
+func (r *RtmtFakeSubsystem) MkdirTemp(dir, pattern string) (string, error) {
+	_, err := configfsi.ParseTsmPath(dir)
+	if err != nil {
+		return "", fmt.Errorf("MkdirTemp: Error %v", err)
+	}
+	return path.Join(dir, pattern), nil
+}
+
+func (r *RtmtFakeSubsystem) ReadFile(name string) ([]byte, error) {
+	p, err := configfsi.ParseTsmPath(name)
+	if err != nil {
+		return nil, fmt.Errorf("ReadFile: Error %v", err)
+	}
+	if p.Attribute != TsmPathTcgMap {
+		return nil, fmt.Errorf("ReadFile expected rtmr attribute %q", p.Attribute)
+	}
+	var rtmrPcrMaps = map[int]string{
+		0: "1,7\n",
+		1: "2-6\n",
+		2: "8-15\n",
+		3: "\n",
+	}
+	return []byte(rtmrPcrMaps[r.RtmrIndex]), nil
+}
+
+func (c *RtmtFakeSubsystem) WriteFile(name string, content []byte) error {
+	p, err := configfsi.ParseTsmPath(name)
+	if err != nil {
+		return fmt.Errorf("WriteFile: %v", err)
+	}
+	if p.Entry == "" || p.Subsystem != RtmrSubsystem {
+		return fmt.Errorf("WriteFile(%q) expected RTMR subsystem entry path", name)
+	}
+	if p.Attribute == TsmRtmrDigest {
+		if c.RtmrIndex < 0 || c.RtmrIndex > 3 {
+			return fmt.Errorf("WriteFile(%q) invalid RTMR index %d. Index can only be 0-3", name, c.RtmrIndex)
+		}
+		if len(content) != int(crypto.SHA384.Size()) {
+			return fmt.Errorf("WriteFile(%q) expected %d bytes, got %d", name, crypto.SHA384.Size(), len(content))
+		}
+		return nil
+	} else if p.Attribute == TsmPathIndex {
+		num, err := strconv.Atoi(string(content))
+		if err == nil {
+			c.RtmrIndex = num
+			return nil
+		}
+	}
+	return fmt.Errorf("WriteFile(%q) expected RTMR attribute entry path", p.Attribute)
+}
+
+func makeFakeRTMRClient() configfsi.Client {
+	return &RtmtFakeSubsystem{}
+}
+
+func TestExtendtoRtmr(t *testing.T) {
+	client := makeFakeRTMRClient()
+	err := ExtendtoRtmrClient(client, 2, crypto.SHA384, []byte("hash"))
+	if err != nil {
+		t.Errorf("ExtendtoRtmrClient failed: %v", err)
+	}
+	if client.(*RtmtFakeSubsystem).RtmrIndex != 2 {
+		t.Errorf("ExtendtoRtmrClient failed: expected index 2, got %d", client.(*RtmtFakeSubsystem).RtmrIndex)
+	}
+}
+
+func TestExtendtoRtmrErr(t *testing.T) {
+	tcs := []struct {
+		rtmr     int
+		crypto   crypto.Hash
+		eventlog []byte
+		wantErr  string
+	}{
+		{rtmr: 5, crypto: crypto.SHA384, eventlog: []byte("event log"), wantErr: "invalid RTMR index 5. Index can only be 0-3"},
+		{rtmr: 2, crypto: crypto.SHA256, eventlog: []byte("event log"), wantErr: "unsupported hash algorithm SHA-256"},
+		{rtmr: 1, crypto: crypto.SHA384, eventlog: []byte("event log"), wantErr: "invalid  index 1, userspace can only extend to rtmr2 or rtmr3"},
+		{rtmr: 3, crypto: crypto.SHA384, eventlog: []byte(""), wantErr: "input event log is empty"},
+	}
+	client := makeFakeRTMRClient()
+	for _, tc := range tcs {
+		err := ExtendtoRtmrClient(client, tc.rtmr, tc.crypto, tc.eventlog)
+		if err == nil || err.Error() != tc.wantErr {
+			t.Fatalf("ExtendtoRtmrClient(%d, %v, %q) failed: %v, want %q", tc.rtmr, tc.crypto, tc.eventlog, err, tc.wantErr)
+		}
+	}
+}

--- a/tools/extend/README.md
+++ b/tools/extend/README.md
@@ -1,0 +1,42 @@
+# `check` CLI tool
+
+This binary is a thin wrapper around the `extend` library to
+extend the measurement into RTMR registers
+
+The tool's input is the event log.
+
+The tool's output is an error or "Success".
+
+## Usage
+
+```
+./extend [options...]
+```
+
+### `-in`
+
+This flag provides the path to the event log to measure. Stdin is "-".
+
+### `quiet`
+
+If set, doesn't write exit errors to Stdout. All results are communicated through exit code.
+
+### `verbosity`
+
+Used to set the verbosity of logger, where higher number means more verbose output.
+
+Default value is `0`.
+
+## Examples
+
+The following example measures an eventlog and extends it measurement into the RTMR2
+register.
+
+```shell
+$ ./extend -in log.in -rtmr 2
+```
+
+## Exit code meaning
+
+*   0: Success
+*   1: Failure due to tool misuse

--- a/tools/extend/extend.go
+++ b/tools/extend/extend.go
@@ -77,9 +77,9 @@ func main() {
 	if err != nil {
 		die(err)
 	}
-	err = extend.ExtendtoRtmr(*rtmr, crypto.SHA384, eventLog)
+	err = extend.ExtendEventLogRtmr(*rtmr, crypto.SHA384, eventLog)
 	if err != nil {
 		die(err)
 	}
-	logger.V(1).Info("Extend meansurement into rtmr registers successfully")
+	logger.V(1).Infof("Extended measurement into rtmr %d successfully", *rtmr)
 }

--- a/tools/extend/extend.go
+++ b/tools/extend/extend.go
@@ -1,0 +1,85 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package main implements a CLI tool for extending measurements into RTMR registers.
+package main
+
+import (
+	"crypto"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/google/go-tdx-guest/rtmr/extend"
+	"github.com/google/logger"
+)
+
+const (
+	// Exit code 1 - tool usage error.
+	exitTool = 1
+)
+
+var (
+	infile    = flag.String("in", "-", "Path to the input eventlog. Stdin is \"-\".")
+	quiet     = flag.Bool("quiet", false, "If true, writes nothing the stdout or stderr. Success is exit code 0, failure exit code 1.")
+	verbosity = flag.Int("verbosity", 0, "The output verbosity. Higher number means more verbose output")
+	rtmr      = flag.Int("rtmr", 3, "The rtmr index. Must be 2 or 3. Defaults to 3.")
+)
+
+func dieWith(err error, exitCode int) {
+	if !*quiet {
+		fmt.Fprintf(os.Stderr, "FATAL: %v\n", err)
+	}
+	os.Exit(exitCode)
+}
+
+func die(err error) {
+	dieWith(err, exitTool)
+}
+
+func getEventLog() ([]byte, error) {
+	var in io.Reader
+	if *infile == "-" {
+		in = os.Stdin
+	} else {
+		f, err := os.Open(*infile)
+		if err != nil {
+			return nil, fmt.Errorf("could not open input file %q: %v", *infile, err)
+		}
+		defer f.Close()
+		in = f
+	}
+	contents, err := io.ReadAll(in)
+	if err != nil {
+		return nil, fmt.Errorf("could not read %q: %v", *infile, err)
+	}
+	return contents, nil
+}
+
+func main() {
+	logger.Init("", false, false, os.Stdout)
+	flag.Parse()
+	logger.SetLevel(logger.Level(*verbosity))
+
+	eventLog, err := getEventLog()
+	if err != nil {
+		die(err)
+	}
+	err = extend.ExtendtoRtmr(*rtmr, crypto.SHA384, eventLog)
+	if err != nil {
+		die(err)
+	}
+	logger.V(1).Info("Extend meansurement into rtmr registers successfully")
+}


### PR DESCRIPTION
TDX Guest exposes 1 MRTD and 3 RTMR registers to record the build and boot measurements of the VM. According to the TDX module spec, user space application can extend additional measurements into RTMR2 and RTMR3.

This extend package is based on the kernel patches from https://github.com/intel/tdx/commits/guest-rtmr

The package has been tested in TDX machines.