### PR TITLE
Add RTMR extend package.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,10 +41,9 @@ jobs:
         with:
           go-version: '${{ matrix.go-version }}'
       - name: Install Protoc
-        uses: arduino/setup-protoc@v1
+        uses: arduino/setup-protoc@v3
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
-          version: 3.12.4
       - name: Install protoc-gen-go
         run: go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28.1
       - name: Check Protobuf Generation

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/google/go-cmp v0.5.7
-	github.com/google/go-configfs-tsm v0.2.2
+	github.com/google/go-configfs-tsm v0.3.2
 	github.com/google/go-sev-guest v0.8.0
 	github.com/google/logger v1.1.1
 	go.uber.org/multierr v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaS
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
-github.com/google/go-configfs-tsm v0.2.2 h1:YnJ9rXIOj5BYD7/0DNnzs8AOp7UcvjfTvt215EWcs98=
-github.com/google/go-configfs-tsm v0.2.2/go.mod h1:EL1GTDFMb5PZQWDviGfZV9n87WeGTR/JUg13RfwkgRo=
+github.com/google/go-configfs-tsm v0.3.2 h1:ZYmHkdQavfsvVGDtX7RRda0gamelUNUhu0A9fbiuLmE=
+github.com/google/go-configfs-tsm v0.3.2/go.mod h1:EL1GTDFMb5PZQWDviGfZV9n87WeGTR/JUg13RfwkgRo=
 github.com/google/go-sev-guest v0.8.0 h1:IIZIqdcMJXgTm1nMvId442OUpYebbWDWa9bi9/lUUwc=
 github.com/google/go-sev-guest v0.8.0/go.mod h1:hc1R4R6f8+NcJwITs0L90fYWTsBpd1Ix+Gur15sqHDs=
 github.com/google/logger v1.1.1 h1:+6Z2geNxc9G+4D4oDO9njjjn2d0wN5d7uOo0vOIW1NQ=

--- a/rtmr/extend.go
+++ b/rtmr/extend.go
@@ -18,7 +18,7 @@ package rtmr
 
 import (
 	"crypto"
-	_ "crypto/sha512" // Registrer SHA384 and SHA512
+	_ "crypto/sha512" // Register SHA384 and SHA512
 	"fmt"
 
 	"github.com/google/go-configfs-tsm/configfs/configfsi"

--- a/rtmr/extend.go
+++ b/rtmr/extend.go
@@ -1,0 +1,71 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package rtmr provides the library functions to extend and read TDX rtmr
+// registers and their tcg maps.
+package rtmr
+
+import (
+	"crypto"
+	_ "crypto/sha512" // Registrer SHA384 and SHA512
+	"fmt"
+
+	"github.com/google/go-configfs-tsm/configfs/configfsi"
+	"github.com/google/go-configfs-tsm/configfs/linuxtsm"
+	"github.com/google/go-configfs-tsm/rtmr"
+)
+
+// ExtendDigestClient extends the measurement to the rtmr with the given client.
+func ExtendDigestClient(client configfsi.Client, rtmrIndex int, digest []byte) error {
+	if rtmrIndex < 0 || rtmrIndex > 3 {
+		return fmt.Errorf("invalid rtmr index %d. For TDX, index can only be 0-3", rtmrIndex)
+	}
+	if len(digest) != crypto.SHA384.Size() {
+		return fmt.Errorf("sha384 digest should be %d bytes, the input is %d bytes", crypto.SHA384.Size(), len(digest))
+	}
+	// TODO: check the TCG mapping of the rtmr index
+	return rtmr.ExtendDigest(client, rtmrIndex, digest)
+}
+
+// ExtendEventLogClient extends the event log to the rtmr with the given client.
+func ExtendEventLogClient(client configfsi.Client, rtmrIndex int, hashAlgo crypto.Hash, eventLog []byte) error {
+	if hashAlgo != crypto.SHA384 {
+		return fmt.Errorf("unsupported hash algorithm %v", hashAlgo)
+	}
+	if len(eventLog) == 0 {
+		return fmt.Errorf("input event log is empty")
+	}
+	sha384 := hashAlgo.New()
+	sha384.Write(eventLog)
+	hash := sha384.Sum(nil)
+	return ExtendDigestClient(client, rtmrIndex, hash)
+}
+
+// ExtendEventLog extends the measurement into the rtmr with the given hash algorithm and event log.
+func ExtendEventLog(rtmrIndex int, hashAlgo crypto.Hash, eventLog []byte) error {
+	client, err := linuxtsm.MakeClient()
+	if err != nil {
+		return err
+	}
+	return ExtendEventLogClient(client, rtmrIndex, hashAlgo, eventLog)
+}
+
+// ExtendDigest extends the measurement into the rtmr with the given digest.
+func ExtendDigest(rtmrIndex int, digest []byte) error {
+	client, err := linuxtsm.MakeClient()
+	if err != nil {
+		return err
+	}
+	return ExtendDigestClient(client, rtmrIndex, digest)
+}

--- a/rtmr/extend_test.go
+++ b/rtmr/extend_test.go
@@ -1,0 +1,80 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rtmr
+
+import (
+	"crypto"
+	"strings"
+	"testing"
+
+	"github.com/google/go-configfs-tsm/configfs/fakertmr"
+)
+
+func TestExtendEventLogOk(t *testing.T) {
+	client := fakertmr.CreateRtmrSubsystem(t.TempDir())
+	err := ExtendEventLogClient(client, 2, crypto.SHA384, []byte("event log"))
+	if err != nil {
+		t.Errorf("ExtendEventlog failed: %v", err)
+	}
+}
+
+func TestExtendDigestOk(t *testing.T) {
+	client := fakertmr.CreateRtmrSubsystem(t.TempDir())
+	var sha384Hash [48]byte
+	err := ExtendDigestClient(client, 2, sha384Hash[:])
+	if err != nil {
+		t.Errorf("ExtendDigest failed: %v", err)
+	}
+}
+
+func TestExtendEventLogErr(t *testing.T) {
+	tcs := []struct {
+		rtmr     int
+		crypto   crypto.Hash
+		eventlog []byte
+		wantErr  string
+	}{
+		{rtmr: 2, crypto: crypto.SHA256, eventlog: []byte("event log"), wantErr: "unsupported hash algorithm SHA-256"},
+		{rtmr: 4, crypto: crypto.SHA384, eventlog: []byte("event log"), wantErr: "index can only be 0-3"},
+		{rtmr: 3, crypto: crypto.SHA384, eventlog: []byte(""), wantErr: "input event log is empty"},
+	}
+	client := fakertmr.CreateRtmrSubsystem(t.TempDir())
+	for _, tc := range tcs {
+		err := ExtendEventLogClient(client, tc.rtmr, tc.crypto, tc.eventlog)
+		if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+			t.Fatalf("ExtendEventLog(%d, %v, %q) failed: %v, want %q", tc.rtmr, tc.crypto, tc.eventlog, err, tc.wantErr)
+		}
+	}
+}
+
+func TestExtendDigestErr(t *testing.T) {
+	var sha384Hash [48]byte
+	var sha512Hash [64]byte
+	tcs := []struct {
+		rtmr    int
+		digest  []byte
+		wantErr string
+	}{
+		{rtmr: 4, digest: sha384Hash[:], wantErr: "index can only be 0-3"},
+		{rtmr: 3, digest: sha512Hash[:], wantErr: "sha384 digest should be 48 bytes"},
+	}
+	client := fakertmr.CreateRtmrSubsystem(t.TempDir())
+	for _, tc := range tcs {
+		err := ExtendDigestClient(client, tc.rtmr, tc.digest)
+		if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+			t.Fatalf("ExtendDigest(%d, %v) failed: %v, want %q", tc.rtmr, tc.digest, err, tc.wantErr)
+		}
+	}
+}


### PR DESCRIPTION
TDX Guest exposes 1 MRTD and 3 RTMR registers to record the build and boot measurements of the VM. According to the TDX module spec, user space application can extend additional measurements into RTMR2 and RTMR3.

This extend package is based on the kernel patches from https://github.com/intel/tdx/commits/guest-rtmr

Also fix the CI according to https://github.com/arduino/setup-protoc