### PR TITLE
Update go-eventlog dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/google/go-cmp v0.6.0
 	github.com/google/go-configfs-tsm v0.3.2
-	github.com/google/go-eventlog v0.0.1
+	github.com/google/go-eventlog v0.0.2-0.20241213203620-f921bdc3aeb0
 	github.com/google/go-sev-guest v0.8.0
 	github.com/google/logger v1.1.1
 	go.uber.org/multierr v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/google/go-configfs-tsm v0.3.2 h1:ZYmHkdQavfsvVGDtX7RRda0gamelUNUhu0A9
 github.com/google/go-configfs-tsm v0.3.2/go.mod h1:EL1GTDFMb5PZQWDviGfZV9n87WeGTR/JUg13RfwkgRo=
 github.com/google/go-eventlog v0.0.1 h1:7lV3gf61LNDhfS9gQplqaJc/j9ztLhKKgZk/lR6vv4Q=
 github.com/google/go-eventlog v0.0.1/go.mod h1:7huE5P8w2NTObSwSJjboHmB7ioBNblkijdzoVa2skfQ=
+github.com/google/go-eventlog v0.0.2-0.20241213203620-f921bdc3aeb0 h1:270O3tFxca1lAXm3JVWqUU4fHlK3EEIEYIfk4koWMkM=
+github.com/google/go-eventlog v0.0.2-0.20241213203620-f921bdc3aeb0/go.mod h1:7huE5P8w2NTObSwSJjboHmB7ioBNblkijdzoVa2skfQ=
 github.com/google/go-sev-guest v0.8.0 h1:IIZIqdcMJXgTm1nMvId442OUpYebbWDWa9bi9/lUUwc=
 github.com/google/go-sev-guest v0.8.0/go.mod h1:hc1R4R6f8+NcJwITs0L90fYWTsBpd1Ix+Gur15sqHDs=
 github.com/google/go-tpm v0.9.0 h1:sQF6YqWMi+SCXpsmS3fd21oPy/vSddwZry4JnmltHVk=

--- a/rtmr/ccel.go
+++ b/rtmr/ccel.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 
 	"github.com/google/go-eventlog/ccel"
-	"github.com/google/go-eventlog/common"
+	"github.com/google/go-eventlog/extract"
 	"github.com/google/go-eventlog/proto/state"
 	"github.com/google/go-eventlog/register"
 	"github.com/google/go-tdx-guest/abi"
@@ -34,7 +34,7 @@ import (
 type ParseTdxCcelOpts struct {
 	Validation   *validate.Options
 	Verification *verify.Options
-	ExtractOpt   *ccel.ExtractOpts
+	ExtractOpt   *extract.Opts
 }
 
 func getRtmrsFromTdQuoteV4(quote *tdxpb.QuoteV4) (*register.RTMRBank, error) {
@@ -78,7 +78,7 @@ func TdxDefaultOpts(tdxNonce []byte) ParseTdxCcelOpts {
 	return ParseTdxCcelOpts{
 		Validation:   policy,
 		Verification: verify.DefaultOptions(),
-		ExtractOpt:   &ccel.ExtractOpts{Loader: common.GRUB},
+		ExtractOpt:   &extract.Opts{Loader: extract.GRUB},
 	}
 }
 
@@ -103,5 +103,5 @@ func ParseCcelWithTdQuote(ccelBytes []byte, tableBytes []byte, tdxAttestationQuo
 		return nil, err
 	}
 	// Parse the event log and replay the event log with the RTMR values.
-	return ccel.ExtractFirmwareLogState(tableBytes, ccelBytes, *rtmrBank, *opts.ExtractOpt)
+	return ccel.ReplayAndExtract(tableBytes, ccelBytes, *rtmrBank, *opts.ExtractOpt)
 }

--- a/rtmr/ccel.go
+++ b/rtmr/ccel.go
@@ -34,7 +34,7 @@ import (
 type ParseTdxCcelOpts struct {
 	Validation   *validate.Options
 	Verification *verify.Options
-	ExtractOpt   *extract.Opts
+	ExtractOpt   extract.Opts
 }
 
 func getRtmrsFromTdQuoteV4(quote *tdxpb.QuoteV4) (*register.RTMRBank, error) {
@@ -78,7 +78,7 @@ func TdxDefaultOpts(tdxNonce []byte) ParseTdxCcelOpts {
 	return ParseTdxCcelOpts{
 		Validation:   policy,
 		Verification: verify.DefaultOptions(),
-		ExtractOpt:   &extract.Opts{Loader: extract.GRUB},
+		ExtractOpt:   extract.Opts{Loader: extract.GRUB},
 	}
 }
 
@@ -103,5 +103,5 @@ func ParseCcelWithTdQuote(ccelBytes []byte, tableBytes []byte, tdxAttestationQuo
 		return nil, err
 	}
 	// Parse the event log and replay the event log with the RTMR values.
-	return ccel.ReplayAndExtract(tableBytes, ccelBytes, *rtmrBank, *opts.ExtractOpt)
+	return ccel.ReplayAndExtract(tableBytes, ccelBytes, *rtmrBank, opts.ExtractOpt)
 }


### PR DESCRIPTION
This updates the dependency on go-eventlog 0.0.1 to the [most recent commit](https://github.com/google/go-eventlog/commit/f921bdc3aeb06b07dfefa6f74226dd44f289c2e5) of that repo. Due to breaking changes (ex. removal of the `common` package) this avoids dependency issues when used in tandem with libraries that depend on newer versions of go-eventlog.