### PR TITLE
Use Golang version supported in ubuntu-latest

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - 1.20.x
+          - 1.21.x
         os:
           - macos-latest
           - ubuntu-latest
@@ -61,7 +61,7 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - 1.20.x
+          - 1.21.x
         os:
           - ubuntu-latest
     name: 'Lint ${{ matrix.dir }} (${{ matrix.os }}, Go ${{ matrix.go-version }})'
@@ -85,7 +85,7 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - 1.20.x
+          - 1.21.x
         os:
           - ubuntu-latest
     name: 'Lint CGO (${{ matrix.os}}, Go ${{ matrix.go-version }})'


### PR DESCRIPTION
https://github.com/actions/runner-images/issues/10636

1.21.* is the oldest supported version since the runner image update in December.