### PR TITLE
Update PCS API response header keys

### DIFF
--- a/pcs/pcs.go
+++ b/pcs/pcs.go
@@ -35,6 +35,15 @@ const (
 	fmspcSize            = 6
 	pceIDSize            = 2
 	tcbComponentSize     = 16
+	// SgxPckCrlIssuerChainPhrase header key retrieves the issuer chain from the Intel PCS API:
+	// https://api.portal.trustedservices.intel.com/content/documentation.html#pcs-revocation-v4
+	SgxPckCrlIssuerChainPhrase = "SGX-PCK-CRL-Issuer-Chain"
+	// SgxQeIdentityIssuerChainPhrase header key retrieves the issuer chain from the Intel PCS API:
+	// https://api.portal.trustedservices.intel.com/content/documentation.html#pcs-enclave-identity-v4
+	SgxQeIdentityIssuerChainPhrase = "SGX-Enclave-Identity-Issuer-Chain"
+	// TcbInfoIssuerChainPhrase header key retrieves the issuer chain from the Intel PCS API:
+	// https://api.portal.trustedservices.intel.com/content/documentation.html#pcs-tcb-info-tdx-v4
+	TcbInfoIssuerChainPhrase = "TCB-Info-Issuer-Chain"
 )
 
 var (

--- a/testing/test_cases.go
+++ b/testing/test_cases.go
@@ -17,6 +17,7 @@ package testing
 
 import (
 	labi "github.com/google/go-tdx-guest/client/linuxabi"
+	"github.com/google/go-tdx-guest/pcs"
 	"github.com/google/go-tdx-guest/testing/testdata"
 )
 
@@ -33,17 +34,17 @@ var qeIdentityIssuerChain = []string{
 
 // PckCrlHeader is the response header for pck crl
 var PckCrlHeader = map[string][]string{
-	"Sgx-Pck-Crl-Issuer-Chain": pckCrlIssuerChain,
+	pcs.SgxPckCrlIssuerChainPhrase: pckCrlIssuerChain,
 }
 
 // TcbInfoHeader is the response header for pck crl
 var TcbInfoHeader = map[string][]string{
-	"Tcb-Info-Issuer-Chain": tcbInfoIssuerChain,
+	pcs.TcbInfoIssuerChainPhrase: tcbInfoIssuerChain,
 }
 
 // QeIdentityHeader is the response header for pck crl
 var QeIdentityHeader = map[string][]string{
-	"Sgx-Enclave-Identity-Issuer-Chain": qeIdentityIssuerChain,
+	pcs.SgxQeIdentityIssuerChainPhrase: qeIdentityIssuerChain,
 }
 
 // TestGetter is a local getter tied to the included sample quote

--- a/verify/verify.go
+++ b/verify/verify.go
@@ -157,23 +157,20 @@ const (
 	tcbInfoVersion    = 3.0
 	qeIdentityVersion = 2.0
 
-	rootCertPhrase                 = "Intel SGX Root CA"
-	intermediateCertPhrase         = "Intel SGX PCK Platform CA"
-	pckCertPhrase                  = "Intel SGX PCK Certificate"
-	processorIssuer                = "Intel SGX PCK Processor CA"
-	processorIssuerID              = "processor"
-	platformIssuer                 = "Intel SGX PCK Platform CA"
-	platformIssuerID               = "platform"
-	sgxPckCrlIssuerChainPhrase     = "Sgx-Pck-Crl-Issuer-Chain"
-	sgxQeIdentityIssuerChainPhrase = "Sgx-Enclave-Identity-Issuer-Chain"
-	tcbInfoIssuerChainPhrase       = "Tcb-Info-Issuer-Chain"
-	tcbInfoPhrase                  = "tcbInfo"
-	enclaveIdentityPhrase          = "enclaveIdentity"
-	certificateType                = "CERTIFICATE"
-	tcbInfoID                      = "TDX"
-	qeIdentityID                   = "TD_QE"
-	tcbSigningPhrase               = "Intel SGX TCB Signing"
-	tcbInfoTdxModuleIDPrefix       = "TDX_"
+	rootCertPhrase           = "Intel SGX Root CA"
+	intermediateCertPhrase   = "Intel SGX PCK Platform CA"
+	pckCertPhrase            = "Intel SGX PCK Certificate"
+	processorIssuer          = "Intel SGX PCK Processor CA"
+	processorIssuerID        = "processor"
+	platformIssuer           = "Intel SGX PCK Platform CA"
+	platformIssuerID         = "platform"
+	tcbInfoPhrase            = "tcbInfo"
+	enclaveIdentityPhrase    = "enclaveIdentity"
+	certificateType          = "CERTIFICATE"
+	tcbInfoID                = "TDX"
+	qeIdentityID             = "TD_QE"
+	tcbSigningPhrase         = "Intel SGX TCB Signing"
+	tcbInfoTdxModuleIDPrefix = "TDX_"
 )
 
 // Options represents verification options for a TDX attestation quote.
@@ -357,7 +354,7 @@ func getPckCrl(ca string, getter trust.HTTPSGetter, collateral *Collateral) erro
 	if err != nil {
 		return CRLUnavailableErr{multierr.Append(err, errors.New("could not fetch PCK CRL"))}
 	}
-	pckCrlIntermediateCert, pckCrlRootCert, err := headerToIssuerChain(header, sgxPckCrlIssuerChainPhrase)
+	pckCrlIntermediateCert, pckCrlRootCert, err := headerToIssuerChain(header, pcs.SgxPckCrlIssuerChainPhrase)
 	if err != nil {
 		return err
 	}
@@ -382,7 +379,7 @@ func getTcbInfo(fmspc string, getter trust.HTTPSGetter, collateral *Collateral) 
 		}
 	}
 
-	tcbInfoIntermediateCert, tcbInfoRootCert, err := headerToIssuerChain(header, tcbInfoIssuerChainPhrase)
+	tcbInfoIntermediateCert, tcbInfoRootCert, err := headerToIssuerChain(header, pcs.TcbInfoIssuerChainPhrase)
 	if err != nil {
 		return &trust.AttestationRecreationErr{
 			Msg: err.Error(),
@@ -418,7 +415,7 @@ func getQeIdentity(getter trust.HTTPSGetter, collateral *Collateral) error {
 		}
 	}
 
-	qeIdentityIntermediateCert, qeIdentityRootCert, err := headerToIssuerChain(header, sgxQeIdentityIssuerChainPhrase)
+	qeIdentityIntermediateCert, qeIdentityRootCert, err := headerToIssuerChain(header, pcs.SgxQeIdentityIssuerChainPhrase)
 	if err != nil {
 		return &trust.AttestationRecreationErr{
 			Msg: err.Error(),


### PR DESCRIPTION
This PR updates the header keys for the following APIs:
- PCS SGX PCK CRL https://api.portal.trustedservices.intel.com/content/documentation.html#pcs-revocation-v4, 
- TDX TCB info https://api.portal.trustedservices.intel.com/content/documentation.html#pcs-tcb-info-tdx-v4,
- QE Identity https://api.portal.trustedservices.intel.com/content/documentation.html#pcs-enclave-identity-v4
along with small refactors by moving them to the `pcs` package and making them exportable by other packages.