### PR TITLE
Canonicalize http header keys from PCS response

### DIFF
--- a/pcs/pcs.go
+++ b/pcs/pcs.go
@@ -22,6 +22,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"net/http"
 	"strconv"
 	"time"
 )
@@ -35,22 +36,30 @@ const (
 	fmspcSize            = 6
 	pceIDSize            = 2
 	tcbComponentSize     = 16
-	// SgxPckCrlIssuerChainPhrase header key retrieves the issuer chain from the Intel PCS API:
+	// sgxPckCrlIssuerChainHeaderKey retrieves the issuer chain from the Intel PCS API:
 	// https://api.portal.trustedservices.intel.com/content/documentation.html#pcs-revocation-v4
-	SgxPckCrlIssuerChainPhrase = "SGX-PCK-CRL-Issuer-Chain"
-	// SgxQeIdentityIssuerChainPhrase header key retrieves the issuer chain from the Intel PCS API:
+	sgxPckCrlIssuerChainHeaderKey = "SGX-PCK-CRL-Issuer-Chain"
+	// sgxQeIdentityIssuerChainHeaderKey retrieves the issuer chain from the Intel PCS API:
 	// https://api.portal.trustedservices.intel.com/content/documentation.html#pcs-enclave-identity-v4
-	SgxQeIdentityIssuerChainPhrase = "SGX-Enclave-Identity-Issuer-Chain"
-	// TcbInfoIssuerChainPhrase header key retrieves the issuer chain from the Intel PCS API:
+	sgxQeIdentityIssuerChainHeaderKey = "SGX-Enclave-Identity-Issuer-Chain"
+	// tcbInfoIssuerChainHeaderKey retrieves the issuer chain from the Intel PCS API:
 	// https://api.portal.trustedservices.intel.com/content/documentation.html#pcs-tcb-info-tdx-v4
-	TcbInfoIssuerChainPhrase = "TCB-Info-Issuer-Chain"
+	tcbInfoIssuerChainHeaderKey = "TCB-Info-Issuer-Chain"
+	// SgxBaseURL is the base URL for fetching SGX related info from the Intel PCS API.
+	SgxBaseURL = "https://api.trustedservices.intel.com/sgx/certification/v4"
+	// TdxBaseURL is the base URL for fetching TDX related info from the Intel PCS API.
+	TdxBaseURL = "https://api.trustedservices.intel.com/tdx/certification/v4"
 )
 
 var (
-	pcsSgxBaseURL = "https://api.trustedservices.intel.com/sgx/certification/v4"
-	pcsTdxBaseURL = "https://api.trustedservices.intel.com/tdx/certification/v4"
-
 	sgxTcbComponentOidPrefix = []int{1, 2, 840, 113741, 1, 13, 1, 2}
+
+	// SgxPckCrlIssuerChainPhrase conforms to the canonicalized header key format used by Go's net/http package.
+	SgxPckCrlIssuerChainPhrase = http.CanonicalHeaderKey(sgxPckCrlIssuerChainHeaderKey)
+	// SgxQeIdentityIssuerChainPhrase conforms to the canonicalized header key format used by Go's net/http package.
+	SgxQeIdentityIssuerChainPhrase = http.CanonicalHeaderKey(sgxQeIdentityIssuerChainHeaderKey)
+	// TcbInfoIssuerChainPhrase conforms to the canonicalized header key format used by Go's net/http package.
+	TcbInfoIssuerChainPhrase = http.CanonicalHeaderKey(tcbInfoIssuerChainHeaderKey)
 
 	// OidSgxExtension is the x509v3 extension for PCK certificate's SGX Extension.
 	OidSgxExtension = asn1.ObjectIdentifier([]int{1, 2, 840, 113741, 1, 13, 1})
@@ -462,15 +471,15 @@ func PckCertificateExtensions(cert *x509.Certificate) (*PckExtensions, error) {
 
 // PckCrlURL  returns the Intel PCS URL for retrieving PCK CRL
 func PckCrlURL(ca string) string {
-	return fmt.Sprintf("%s/pckcrl?ca=%s&encoding=der", pcsSgxBaseURL, ca)
+	return fmt.Sprintf("%s/pckcrl?ca=%s&encoding=der", SgxBaseURL, ca)
 }
 
 // TcbInfoURL returns the Intel PCS URL for retrieving TCB Info
 func TcbInfoURL(fmspc string) string {
-	return fmt.Sprintf("%s/tcb?fmspc=%s", pcsTdxBaseURL, fmspc)
+	return fmt.Sprintf("%s/tcb?fmspc=%s", TdxBaseURL, fmspc)
 }
 
 // QeIdentityURL returns the Intel PCS URL for retrieving QE identity
 func QeIdentityURL() string {
-	return fmt.Sprintf("%s/qe/identity", pcsTdxBaseURL)
+	return fmt.Sprintf("%s/qe/identity", TdxBaseURL)
 }

--- a/pcs/pcs_test.go
+++ b/pcs/pcs_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestPckCrlURL(t *testing.T) {
-	want := pcsSgxBaseURL + "/pckcrl?ca=platform&encoding=der"
+	want := SgxBaseURL + "/pckcrl?ca=platform&encoding=der"
 
 	if got := PckCrlURL("platform"); got != want {
 		t.Errorf(`PckCrlURL("platform") = %q. Expected %q`, got, want)
@@ -28,7 +28,7 @@ func TestPckCrlURL(t *testing.T) {
 }
 
 func TestTcbInfoURL(t *testing.T) {
-	want := pcsTdxBaseURL + "/tcb?fmspc=50806f000000"
+	want := TdxBaseURL + "/tcb?fmspc=50806f000000"
 	fmspcBytes := []byte{80, 128, 111, 0, 0, 0}
 	fmspc := hex.EncodeToString(fmspcBytes)
 	if got := TcbInfoURL(fmspc); got != want {
@@ -37,7 +37,7 @@ func TestTcbInfoURL(t *testing.T) {
 }
 
 func TestQeIdentityURL(t *testing.T) {
-	want := pcsTdxBaseURL + "/qe/identity"
+	want := TdxBaseURL + "/qe/identity"
 	if got := QeIdentityURL(); got != want {
 		t.Errorf("QEIdentityURL() = %q. Expected %q", got, want)
 	}


### PR DESCRIPTION
PR https://github.com/google/go-tdx-guest/pull/59 aims to update and export the Intel PCS header keys. However, doing so will cause potential issues for customers when they are trying to use the tooling `tools/check` to validate TD quote against the real-time intel collaterals. 
```
./check -in quote.dat -inform bin -get_collateral=true -check_crl=true
>> FATAL: could not verify the TDX Quote: unable to receive tcbInfo: "TCB-Info-Issuer-Chain" is empty
```

The root cause is Go's `net/http` package automatically canonicalizes header keys. It will convert the raw header key `TCB-Info-Chain` to `Tcb-Info-Chain` silently, causing the failure to retrieve the issuer chain from the response header. To avoid this inconsistency between systems, we should follow the standard to canonicalize all header keys.

This PR includes the following changes:
- Export the **canonicalized** header keys 
- Export other constants from pcs.go.