### PR TITLE
Breakdown the top-level timestamp into granular timestamps for different collaterals for more accurate timing comparisons

### DIFF
--- a/tools/check/check_test.go
+++ b/tools/check/check_test.go
@@ -57,7 +57,11 @@ func TestMain(m *testing.M) {
 	check = "./check"
 
 	logger.Init("CheckTestLog", false, false, os.Stderr)
-	os.Exit(m.Run())
+
+	code := m.Run()
+	// Cleanup `check` binary after all tests are done.
+	os.Remove("check")
+	os.Exit(code)
 }
 
 func withBaseArgs(config string, args ...string) []string {


### PR DESCRIPTION
The current `verify.Options` only contains one timestamp field `Now` to verify the validity of certificates and collaterals. This is true if we want to validate ref values against the real-time Intel collaterals. However, this model has changed as we introduce Google cached RIMs for Intel-sourced ref values - that is, we'll cache various collaterals (including PCKCRL, TDX TCB, TD QE) at different timestamps. We should breakdown the single timestamp into more granular timestamps for different collaterals to have more accurate timing comparisons.  

To address this issue, we should snapshot the timestamps when we cache Google RIMs (including TcbInfo, QeIdentity, PCK CRL, etc.), and expand the existing time option from `verify` package to have a set of timestamps that allow for accurate timing comparisons for each ref value. 

This PR includes the following changes:
- Expand a timestamp to a set of timestamps for TdxTcb, QeIdentity, PckCrl, RootCaCrl, and PckCertChain within `verify.Options`
- Tests cleanup: remove the `check` binary after all related tests are done.     