### PR TITLE
Normalize FMSPC strings and compare them in a memory-efficient way

### DIFF
--- a/verify/verify.go
+++ b/verify/verify.go
@@ -32,6 +32,7 @@ import (
 	"net/url"
 	"os"
 	"reflect"
+	"strings"
 	"time"
 
 	"github.com/google/go-tdx-guest/abi"
@@ -1007,7 +1008,8 @@ func checkTcbInfoTcbStatus(tcbInfo pcs.TcbInfo, tdQuoteBody *pb.TDQuoteBody, pck
 
 func verifyTdQuoteBody(tdQuoteBody *pb.TDQuoteBody, tdQuoteBodyOptions *tdQuoteBodyOptions) error {
 	logger.V(2).Infof("FMSPC from PCK Certificate is %q, and FMSPC value from Intel PCS's reported TDX TCB info is %q", tdQuoteBodyOptions.pckCertExtensions.FMSPC, tdQuoteBodyOptions.tcbInfo.Fmspc)
-	if tdQuoteBodyOptions.pckCertExtensions.FMSPC != tdQuoteBodyOptions.tcbInfo.Fmspc {
+	// Converting FMSPCs to the same case and compare them in a memory-efficient way.
+	if !strings.EqualFold(tdQuoteBodyOptions.pckCertExtensions.FMSPC, tdQuoteBodyOptions.tcbInfo.Fmspc) {
 		return fmt.Errorf("FMSPC from PCK Certificate(%q) is not equal to FMSPC value from Intel PCS's reported TDX TCB info(%q)", tdQuoteBodyOptions.pckCertExtensions.FMSPC, tdQuoteBodyOptions.tcbInfo.Fmspc)
 	}
 

--- a/verify/verify_test.go
+++ b/verify/verify_test.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -491,6 +492,18 @@ func TestVerifyUsingTcbInfoV4(t *testing.T) {
 	}
 	if err := verifyTdQuoteBody(quote.GetTdQuoteBody(), &tdQuoteBodyOptions{tcbInfo: tcbInfo, pckCertExtensions: ext}); err != nil {
 		t.Error(err)
+	}
+
+	// Convert fmspc value to uppercase.
+	tcbInfo.Fmspc = strings.ToUpper(tcbInfo.Fmspc)
+	if err := verifyTdQuoteBody(quote.GetTdQuoteBody(), &tdQuoteBodyOptions{tcbInfo: tcbInfo, pckCertExtensions: ext}); err != nil {
+		t.Errorf("verifyTdQuoteBody() failed with upppercased FMSPC value: %v", err)
+	}
+
+	// Convert fmspc value to lowercase.
+	tcbInfo.Fmspc = strings.ToLower(tcbInfo.Fmspc)
+	if err := verifyTdQuoteBody(quote.GetTdQuoteBody(), &tdQuoteBodyOptions{tcbInfo: tcbInfo, pckCertExtensions: ext}); err != nil {
+		t.Errorf("verifyTdQuoteBody() failed with lowercased FMSPC value: %v", err)
 	}
 }
 


### PR DESCRIPTION
The current `verify` package compares the FMSPC retrieved from SGX PCK Cert with the FMSPC from Intel PCS response. The FMSPC from SGX PCK Cert is always lowercased (e.g, `00806f050000`). However, the FMSPC value from [PCS API](https://api.portal.trustedservices.intel.com/content/documentation.html#pcs-tcb-info-tdx-v4) could be uppercased or lowercased because `fmspc` is a query parameter and follows the pattern of `^[0-9a-fA-F]{12}$`. 

To ensure a consistent verification result, we should normalize FMSPC values when doing comparison.

This PR includes the following changes:
- Normalize FMSPC strings and compare them in a memory-efficient way (following guidance from https://staticcheck.dev/docs/checks#SA6005)
- More unit test coverages.