### PR TITLE
Correctly return errors from SupportedTcbLevelsFromCollateral

### DIFF
--- a/verify/verify.go
+++ b/verify/verify.go
@@ -1385,12 +1385,12 @@ func SupportedTcbLevelsFromCollateral(quote any, options *Options) (pcs.TcbLevel
 		var err error
 		foundTcbInfo, tcbErr := readTcbInfoTcbStatus(options.collateral.TdxTcbInfo.TcbInfo, q.GetTdQuoteBody(), options.pckCertExtensions)
 		if tcbErr != nil {
-			multierr.Combine(err, tcbErr)
+			err = multierr.Combine(err, tcbErr)
 		}
 
 		foundQe, qeErr := readQeTcbStatus(options.collateral.QeIdentity.EnclaveIdentity.TcbLevels, q.GetSignedData().GetCertificationData().GetQeReportCertificationData().GetQeReport().GetIsvSvn())
 		if qeErr != nil {
-			multierr.Combine(err, qeErr)
+			err = multierr.Combine(err, qeErr)
 		}
 		return foundTcbInfo, foundQe, err
 	default:

--- a/verify/verify_test.go
+++ b/verify/verify_test.go
@@ -889,4 +889,22 @@ func TestSupportedTcbLevelsFromCollateral(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("regression test no TCB level", func(t *testing.T) {
+		collateral, err := obtainCollateral(fmspc, ca, &Options{Getter: getter})
+		if err != nil {
+			t.Fatal(err)
+		}
+		collateral.QeIdentity.EnclaveIdentity.TcbLevels = nil
+		_, _, err = SupportedTcbLevelsFromCollateral(quote, &Options{
+			GetCollateral:     true,
+			Now:               testTimeSet(currentTime),
+			chain:             chain,
+			collateral:        collateral,
+			pckCertExtensions: ext,
+		})
+		if err == nil {
+			t.Fatal("SupportedTcbLevelsFromCollateral() didn't return an error when TcbLevels were missing")
+		}
+	})
 }


### PR DESCRIPTION
The return value of `multierr.Combine` was not assigned to the function's return value, so `readTcbInfoTcbStatus` and `readQeTcbStatus` never caused an error.

I found this because I ran `golangci-lint` with the default configuration on the codebase. CI is configured with https://github.com/google/go-tdx-guest/blob/b5d0f3c34e7e2c0a2dd6b84a0906cd63edb7a9ca/.github/workflows/CI.yml#L80 so it never showed up there. I understand that there are some false-positives, but maybe it would make sense to mark them explicitly ignored?