### PR TITLE
Add CollateralUpdate Option for PCS Identity API

### DIFF
--- a/pcs/pcs.go
+++ b/pcs/pcs.go
@@ -223,6 +223,16 @@ const (
 	TcbComponentStatusRevoked TcbComponentStatus = "Revoked"
 )
 
+// CollateralUpdate represents the `update` query parameter of the Intel PCS API service
+type CollateralUpdate string
+
+const (
+	// CollateralUpdateStandard represents the standard access channel to updated collateral provided as part of a TCB recovery event
+	CollateralUpdateStandard CollateralUpdate = "standard"
+	// CollateralUpdateEarly represents the early access channel to updated collaterals provided as part of a TCB recovery event
+	CollateralUpdateEarly CollateralUpdate = "early"
+)
+
 // UnmarshalJSON for TcbComponentStatus maps tcb status to corresponding valid strings
 func (st *TcbComponentStatus) UnmarshalJSON(s []byte) error {
 	unquotedStatus, err := strconv.Unquote(string(s))
@@ -475,11 +485,11 @@ func PckCrlURL(ca string) string {
 }
 
 // TcbInfoURL returns the Intel PCS URL for retrieving TCB Info
-func TcbInfoURL(fmspc string) string {
-	return fmt.Sprintf("%s/tcb?fmspc=%s", TdxBaseURL, fmspc)
+func TcbInfoURL(fmspc string, update CollateralUpdate) string {
+	return fmt.Sprintf("%s/tcb?fmspc=%s&update=%s", TdxBaseURL, fmspc, update)
 }
 
 // QeIdentityURL returns the Intel PCS URL for retrieving QE identity
-func QeIdentityURL() string {
-	return fmt.Sprintf("%s/qe/identity", TdxBaseURL)
+func QeIdentityURL(update CollateralUpdate) string {
+	return fmt.Sprintf("%s/qe/identity?update=%s", TdxBaseURL, update)
 }

--- a/pcs/pcs_test.go
+++ b/pcs/pcs_test.go
@@ -28,17 +28,58 @@ func TestPckCrlURL(t *testing.T) {
 }
 
 func TestTcbInfoURL(t *testing.T) {
-	want := TdxBaseURL + "/tcb?fmspc=50806f000000"
 	fmspcBytes := []byte{80, 128, 111, 0, 0, 0}
 	fmspc := hex.EncodeToString(fmspcBytes)
-	if got := TcbInfoURL(fmspc); got != want {
-		t.Errorf("TcbInfoURL(%q) = %q. Expected %q", fmspc, got, want)
+
+	testCases := []struct {
+		name          string
+		updateChannel CollateralUpdate
+		wantUrl       string
+	}{
+		{
+			name:          "success with standard access",
+			updateChannel: CollateralUpdateStandard,
+			wantUrl:       TdxBaseURL + "/tcb?fmspc=50806f000000&update=standard",
+		},
+		{
+			name:          "success with early access",
+			updateChannel: CollateralUpdateEarly,
+			wantUrl:       TdxBaseURL + "/tcb?fmspc=50806f000000&update=early",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := TcbInfoURL(fmspc, tc.updateChannel); got != tc.wantUrl {
+				t.Errorf("TcbInfoURL(%q) = %q. Expected %q", fmspc, got, tc.wantUrl)
+			}
+		})
 	}
 }
 
 func TestQeIdentityURL(t *testing.T) {
-	want := TdxBaseURL + "/qe/identity"
-	if got := QeIdentityURL(); got != want {
-		t.Errorf("QEIdentityURL() = %q. Expected %q", got, want)
+	testCases := []struct {
+		name          string
+		updateChannel CollateralUpdate
+		wantUrl       string
+	}{
+		{
+			name:          "success with standard access",
+			updateChannel: CollateralUpdateStandard,
+			wantUrl:       TdxBaseURL + "/qe/identity?update=standard",
+		},
+		{
+			name:          "success with early access",
+			updateChannel: CollateralUpdateEarly,
+			wantUrl:       TdxBaseURL + "/qe/identity?update=early",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := QeIdentityURL(tc.updateChannel); got != tc.wantUrl {
+				t.Errorf("QEIdentityURL() = %q. Expected %q", got, tc.wantUrl)
+			}
+		})
 	}
 }

--- a/testing/test_cases.go
+++ b/testing/test_cases.go
@@ -50,11 +50,19 @@ var QeIdentityHeader = map[string][]string{
 // TestGetter is a local getter tied to the included sample quote
 var TestGetter = &Getter{
 	Responses: map[string]HTTPResponse{
-		"https://api.trustedservices.intel.com/tdx/certification/v4/qe/identity": {
+		"https://api.trustedservices.intel.com/tdx/certification/v4/qe/identity?update=standard": {
 			Header: QeIdentityHeader,
 			Body:   testdata.QeIdentityBody,
 		},
-		"https://api.trustedservices.intel.com/tdx/certification/v4/tcb?fmspc=50806f000000": {
+		"https://api.trustedservices.intel.com/tdx/certification/v4/qe/identity?update=early": {
+			Header: QeIdentityHeader,
+			Body:   testdata.QeIdentityBody,
+		},
+		"https://api.trustedservices.intel.com/tdx/certification/v4/tcb?fmspc=50806f000000&update=standard": {
+			Header: TcbInfoHeader,
+			Body:   testdata.TcbInfoBody,
+		},
+		"https://api.trustedservices.intel.com/tdx/certification/v4/tcb?fmspc=50806f000000&update=early": {
 			Header: TcbInfoHeader,
 			Body:   testdata.TcbInfoBody,
 		},

--- a/verify/verify_test.go
+++ b/verify/verify_test.go
@@ -379,23 +379,62 @@ func TestGetTcbInfo(t *testing.T) {
 	fmspc := hex.EncodeToString(fmspcBytes)
 
 	collateral := &Collateral{}
-	if err := getTcbInfo(fmspc, getter, collateral); err != nil {
-		t.Error(err)
+
+	testCases := []struct {
+		name          string
+		updateChannel pcs.CollateralUpdate
+	}{
+		{
+			name:          "success with standard access",
+			updateChannel: pcs.CollateralUpdateStandard,
+		},
+		{
+			name:          "success with early access",
+			updateChannel: pcs.CollateralUpdateEarly,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := getTcbInfo(fmspc, tc.updateChannel, getter, collateral); err != nil {
+				t.Error(err)
+			}
+		})
 	}
 }
 
 func TestGetQeIdentity(t *testing.T) {
 	getter := testcases.TestGetter
 	collateral := &Collateral{}
-	if err := getQeIdentity(getter, collateral); err != nil {
-		t.Error(err)
+
+	testCases := []struct {
+		name          string
+		updateChannel pcs.CollateralUpdate
+	}{
+		{
+			name:          "success with standard access",
+			updateChannel: pcs.CollateralUpdateStandard,
+		},
+		{
+			name:          "success with early access",
+			updateChannel: pcs.CollateralUpdateEarly,
+		},
 	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := getQeIdentity(tc.updateChannel, getter, collateral); err != nil {
+				t.Error(err)
+			}
+		})
+	}
+
 }
 
 func TestGetRootCRL(t *testing.T) {
 	getter := testcases.TestGetter
 	collateral := &Collateral{}
-	if err := getQeIdentity(getter, collateral); err != nil {
+	if err := getQeIdentity(pcs.CollateralUpdateStandard, getter, collateral); err != nil {
 		t.Fatal(err)
 	}
 
@@ -474,7 +513,7 @@ func TestVerifyUsingTcbInfoV4(t *testing.T) {
 	fmspc := hex.EncodeToString(fmspcBytes)
 
 	collateral := &Collateral{}
-	if err := getTcbInfo(fmspc, getter, collateral); err != nil {
+	if err := getTcbInfo(fmspc, pcs.CollateralUpdateStandard, getter, collateral); err != nil {
 		t.Fatal(err)
 	}
 	anyQuote, err := abi.QuoteToProto(testdata.RawQuote)
@@ -524,7 +563,7 @@ func TestNegativeVerifyUsingTcbInfoV4(t *testing.T) {
 	fmspc := hex.EncodeToString(fmspcBytes)
 
 	collateral := &Collateral{}
-	if err := getTcbInfo(fmspc, getter, collateral); err != nil {
+	if err := getTcbInfo(fmspc, pcs.CollateralUpdateStandard, getter, collateral); err != nil {
 		t.Fatal(err)
 	}
 	anyQuote, err := abi.QuoteToProto(testdata.RawQuote)
@@ -580,7 +619,7 @@ func TestVerifyUsingQeIdentityV4(t *testing.T) {
 	getter := testcases.TestGetter
 
 	collateral := &Collateral{}
-	if err := getQeIdentity(getter, collateral); err != nil {
+	if err := getQeIdentity(pcs.CollateralUpdateStandard, getter, collateral); err != nil {
 		t.Fatal(err)
 	}
 	anyQuote, err := abi.QuoteToProto(testdata.RawQuote)
@@ -604,7 +643,7 @@ func TestNegativeVerifyUsingQeIdentityV4(t *testing.T) {
 	getter := testcases.TestGetter
 
 	collateral := &Collateral{}
-	if err := getQeIdentity(getter, collateral); err != nil {
+	if err := getQeIdentity(pcs.CollateralUpdateStandard, getter, collateral); err != nil {
 		t.Fatal(err)
 	}
 	anyQuote, err := abi.QuoteToProto(testdata.RawQuote)
@@ -657,7 +696,7 @@ func TestNegativeTcbInfoTcbStatusV4(t *testing.T) {
 	fmspc := hex.EncodeToString(fmspcBytes)
 
 	collateral := &Collateral{}
-	if err := getTcbInfo(fmspc, getter, collateral); err != nil {
+	if err := getTcbInfo(fmspc, pcs.CollateralUpdateStandard, getter, collateral); err != nil {
 		t.Fatal(err)
 	}
 	anyQuote, err := abi.QuoteToProto(testdata.RawQuote)
@@ -706,7 +745,7 @@ func TestNegativeCheckQeStatusV4(t *testing.T) {
 	getter := testcases.TestGetter
 
 	collateral := &Collateral{}
-	if err := getQeIdentity(getter, collateral); err != nil {
+	if err := getQeIdentity(pcs.CollateralUpdateStandard, getter, collateral); err != nil {
 		t.Fatal(err)
 	}
 	anyQuote, err := abi.QuoteToProto(testdata.RawQuote)
@@ -750,7 +789,7 @@ func TestValidateCRL(t *testing.T) {
 	if err := getPckCrl(ca, getter, collateral); err != nil {
 		t.Fatal(err)
 	}
-	if err := getQeIdentity(getter, collateral); err != nil {
+	if err := getQeIdentity(pcs.CollateralUpdateStandard, getter, collateral); err != nil {
 		t.Fatal(err)
 	}
 	if err := getRootCrl(getter, collateral); err != nil {


### PR DESCRIPTION
Partially addresses https://github.com/google/go-tdx-guest/issues/66, by introducing support for the `update` query parameter in the Intel PCS API. This allows users to specify whether they want to retrieve collateral using the standard (typically 12-month "Out of date") or early access update channel. Partially address.

The changes introduce a new `CollateralUpdate` type in `pcs.go` and modify the helper function that generates the API URLs. Additionally, a new `CollateralUpdate` option is added to `verify.Options`. On the call to `obtainCollateral`, this option defaults to `CollateralUpdateStandard`, which mirrors the previous behaviour, where the field was omitted and interpreted by the PCS API as "default".