### PR TITLE
Tooling: Add parse_ccel option to parse CCEL event logs and output the parsed results

### DIFF
--- a/tools/check/README.md
+++ b/tools/check/README.md
@@ -31,6 +31,14 @@ Default value is `bin`.
 
 If set, doesn't write exit errors to Stdout. All results are communicated through exit code.
 
+### `-parse_ccel`
+
+If true, parses a Confidential Computing event log and replays the parsed event log
+against the RTMR banks extracted from the verified TD quote. 
+The parsed results are then saved to a **result.textproto** file in the current directory.
+
+Default `false`.
+
 ### `-verbosity`
 
 Used to set the verbosity of logger, where higher number means more verbose output.


### PR DESCRIPTION
This PR introduces changes to add an optional flag to the CLI to allow for parsing CCEL and writing its results. This would be useful for users who are interested in the output of the `check` tooling. This would be beneficial for GDC integration since collecting `FirmwareLogState` is a part of golden image reference provisioning process(see b/411411353). 

Successfully tested in a TDX CVM with the CLI to output the result.