### PR TITLE
Add eventlogs CLI to parse unverified CCEL logs for debugging purpose

### DIFF
--- a/tools/eventlogs/README.md
+++ b/tools/eventlogs/README.md
@@ -1,0 +1,48 @@
+# `eventlogs` CLI tool
+
+This binary is a thin wrapper around the `tcg` library to parse unverified CCEL logs for debugging purpose.
+
+The tool takes a CCEL log file as input and outputs the parsed events in textproto format to either standard output or a specified file.
+
+*Note*: The event logs parsed by this tool are NOT replayed against the RTMR values and are therefore unverified. The output includes the digest corresponding to the provided hash algorithm. If an event does not contain a digest for that hash, the field will be empty.
+
+
+## Usage
+
+```
+./eventlogs [options...]
+```
+
+### `-in`
+
+Specifies the path to the input CCEL log file.
+
+Default: `/sys/firmware/acpi/tables/data/CCEL`
+
+### `-out`
+
+Path to output file in textproto format to write parsed logs to.
+
+Default is empty, interpreted as stdout.
+
+
+### `-verbose`
+
+If set, then the logger can append INFO and WARNING logs to stdout as per the verbosity level. Default logger has verbosity set to `0`, so verbosity option should be set to appropriate value to append INFO and WARN logs at variable verbosity levels to stdout.
+
+Default value is `false`.
+
+### `-verbosity`
+
+Used to set the verbosity of logger, where higher number means more verbose output.
+
+Default value is `0`.
+
+
+## Examples
+
+The following example parses a specific CCEL file, and output to a new file.
+
+```shell
+$ ./eventlogs -in ccel.dat -out parsed_logs.textproto
+```

--- a/tools/eventlogs/eventlogs.go
+++ b/tools/eventlogs/eventlogs.go
@@ -1,0 +1,122 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package main implements a CLI tool for parsing CCEL event logs in a human-readable format.
+package main
+
+import (
+	"crypto"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/google/go-eventlog/register"
+	"github.com/google/go-eventlog/tcg"
+	"github.com/google/logger"
+	"google.golang.org/protobuf/encoding/prototext"
+
+	pb "github.com/google/go-eventlog/proto/state"
+)
+
+var (
+	infile = flag.String("in", "/sys/firmware/acpi/tables/data/CCEL", "Path to the CCEL event log to parse.")
+	out    = flag.String("out", "", "Path to output file to write parsed event logs to. The output file will be in a textproto format"+
+		"If unset, outputs to stdout.")
+	verbose   = flag.Bool("v", false, "Enable verbose logging.")
+	verbosity = flag.Int("verbosity", 0, "The output verbosity. Higher number means more verbose output")
+)
+
+func readCCEL() ([]byte, error) {
+	file, err := os.Open(*infile)
+	if err != nil {
+		return nil, fmt.Errorf("could not open %q: %v", *infile, err)
+	}
+
+	defer func() {
+		if file != nil {
+			file.Close()
+		}
+	}()
+
+	contents, err := io.ReadAll(file)
+	if err != nil {
+		return nil, fmt.Errorf("could not read %q: %v", *infile, err)
+	}
+	return contents, nil
+}
+
+func outWriter() (io.Writer, *os.File, error) {
+	if *out == "" {
+		return os.Stdout, nil, nil
+	}
+	file, err := os.Create(*out)
+	if err != nil {
+		return nil, nil, err
+	}
+	return file, file, nil
+}
+
+func outputEventLog(events []*pb.Event, out io.Writer) error {
+	mo := prototext.MarshalOptions{
+		Multiline: true,
+		Indent:    " ",
+		EmitASCII: true,
+	}
+
+	var bytes []byte
+	var err error
+	for _, event := range events {
+		bytes, err = mo.MarshalAppend(bytes, event)
+		if err != nil {
+			return err
+		}
+		bytes = append(bytes, []byte("\n")...)
+	}
+	out.Write(bytes)
+	return nil
+}
+
+func main() {
+	flag.Parse()
+	logger.Init("", *verbose, false, os.Stderr)
+	logger.SetLevel(logger.Level(*verbosity))
+
+	rawEventLog, err := readCCEL()
+	if err != nil {
+		logger.Fatal(err)
+	}
+
+	eventlog, err := tcg.ParseEventLog(rawEventLog, tcg.ParseOpts{AllowPadding: true})
+	if err != nil {
+		logger.Fatalf("Failed to parse CCEL event log: %v", err)
+	}
+
+	// RTMR uses SHA384 to hash
+	events := tcg.ConvertToPbEvents(crypto.SHA384, eventlog.Events(register.HashSHA384))
+
+	outwriter, filetoclose, err := outWriter()
+	if err != nil {
+		logger.Fatalf("Failed to open output file: %v", err)
+	}
+	defer func() {
+		if filetoclose != nil {
+			filetoclose.Close()
+		}
+	}()
+
+	if err := outputEventLog(events, outwriter); err != nil {
+		logger.Fatal(err)
+	}
+}


### PR DESCRIPTION
This is to simulate [tdx_eventlogs](https://github.com/cc-api/tdx-measure-python/blob/main/tdx_eventlogs) provided by Intel to parse CCEL logs for debugging purpose.