### PR TITLE
Add functionality to dynamically choose path of rtmr interface in Ext…

### DIFF
--- a/client/client_linux.go
+++ b/client/client_linux.go
@@ -82,7 +82,9 @@ func (d *LinuxDevice) Ioctl(command uintptr, req any) (uintptr, error) {
 	case *labi.TdxQuoteReq:
 		abi := sreq.ABI()
 		result, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(d.fd), command, uintptr(abi.Pointer()))
-		abi.Finish(sreq)
+		if err := abi.Finish(sreq); err != nil {
+			return 0, fmt.Errorf("failed to finish ABI request: %w", err)
+		}
 		if errno == unix.EBUSY {
 			return 0, errno
 		} else if errno == unix.ENOTTY {

--- a/rtmr/extend.go
+++ b/rtmr/extend.go
@@ -21,11 +21,41 @@ import (
 	"crypto"
 	_ "crypto/sha512" // Register SHA384 and SHA512
 	"fmt"
+	"os"
 
 	"github.com/google/go-configfs-tsm/configfs/configfsi"
 	"github.com/google/go-configfs-tsm/configfs/linuxtsm"
 	"github.com/google/go-configfs-tsm/rtmr"
 )
+
+const (
+	// Defines the legacy rtmr file path.
+	legacyRTMRPath = "/sys/kernel/config/tsm/rtmrs"
+)
+
+// ExtendDigestSysfs extends the measurement to the rtmr through the sysfs interface.
+// This is the modern method for extending TDX rtmr.
+func ExtendDigestSysfs(rtmrIndex int, digest []byte) error {
+	if rtmrIndex < 0 || rtmrIndex > 3 {
+		return fmt.Errorf("invalid rtmr index %d. For TDX, index can only be 0-3", rtmrIndex)
+	}
+	if len(digest) != crypto.SHA384.Size() {
+		return fmt.Errorf("sha384 digest should be %d bytes, the input is %d bytes", crypto.SHA384.Size(), len(digest))
+	}
+	// The sysfs file is an interface for rtmr. Each write operation functions
+	// as an "extend" operation, not a normal file write.
+	filePath := fmt.Sprintf("/sys/class/misc/tdx_guest/measurements/rtmr%d:sha384", rtmrIndex)
+	file, err := os.OpenFile(filePath, os.O_WRONLY, 0)
+	if err != nil {
+		return fmt.Errorf("failed to open TDX RTMR file %s: %w", filePath, err)
+	}
+	defer file.Close()
+
+	if _, err = file.WriteAt(digest, 0); err != nil {
+		return fmt.Errorf("failed to write data to %s at offset 0: %w", filePath, err)
+	}
+	return nil
+}
 
 // ExtendDigestClient extends the measurement to the rtmr with the given client.
 func ExtendDigestClient(client configfsi.Client, rtmrIndex int, digest []byte) error {
@@ -37,6 +67,21 @@ func ExtendDigestClient(client configfsi.Client, rtmrIndex int, digest []byte) e
 	}
 	// TODO: check the TCG mapping of the rtmr index
 	return rtmr.ExtendDigest(client, rtmrIndex, digest)
+}
+
+// ExtendEventLogSysfs extends the event log to the rtmr through the sysfs interface.
+func ExtendEventLogSysfs(rtmrIndex int, hashAlgo crypto.Hash, eventLog []byte) error {
+	if hashAlgo != crypto.SHA384 {
+		return fmt.Errorf("unsupported hash algorithm %v", hashAlgo)
+	}
+	if len(eventLog) == 0 {
+		return fmt.Errorf("input event log is empty")
+	}
+
+	sha384 := hashAlgo.New()
+	sha384.Write(eventLog)
+	hash := sha384.Sum(nil)
+	return ExtendDigestSysfs(rtmrIndex, hash)
 }
 
 // ExtendEventLogClient extends the event log to the rtmr with the given client.
@@ -54,19 +99,41 @@ func ExtendEventLogClient(client configfsi.Client, rtmrIndex int, hashAlgo crypt
 }
 
 // ExtendEventLog extends the measurement into the rtmr with the given hash algorithm and event log.
+// It checks for the existence of the legacy configfs path to decide whether to use the client or sysfs method.
 func ExtendEventLog(rtmrIndex int, hashAlgo crypto.Hash, eventLog []byte) error {
-	client, err := linuxtsm.MakeClient()
-	if err != nil {
-		return err
+	// Check if the legacy configfs path exists to determine the extension method.
+	_, err := os.Stat(legacyRTMRPath)
+	if err == nil {
+		// If the path exists, use the client method.
+		client, err := linuxtsm.MakeClient()
+		if err != nil {
+			return err
+		}
+		return ExtendEventLogClient(client, rtmrIndex, hashAlgo, eventLog)
+	} else if os.IsNotExist(err) {
+		// If the configfs path does not exist, use the sysfs interface instead.
+		return ExtendEventLogSysfs(rtmrIndex, hashAlgo, eventLog)
 	}
-	return ExtendEventLogClient(client, rtmrIndex, hashAlgo, eventLog)
+	// Handle other unexpected errors from os.Stat.
+	return fmt.Errorf("failed to check for directory %s: %w", legacyRTMRPath, err)
 }
 
 // ExtendDigest extends the measurement into the rtmr with the given digest.
+// It checks for the existence of the legacy configfs path to decide whether to use the client or sysfs method.
 func ExtendDigest(rtmrIndex int, digest []byte) error {
-	client, err := linuxtsm.MakeClient()
-	if err != nil {
-		return err
+	// Check if the legacy configfs path exists to determine the extension method.
+	_, err := os.Stat(legacyRTMRPath)
+	if err == nil {
+		// If the path exists, use the client method.
+		client, err := linuxtsm.MakeClient()
+		if err != nil {
+			return err
+		}
+		return ExtendDigestClient(client, rtmrIndex, digest)
+	} else if os.IsNotExist(err) {
+		// If the configs path does not exist, use the sysfs interface instead.
+		return ExtendDigestSysfs(rtmrIndex, digest)
 	}
-	return ExtendDigestClient(client, rtmrIndex, digest)
+	// Handle other unexpected errors from os.Stat.
+	return fmt.Errorf("failed to check for directory %s: %w", legacyRTMRPath, err)
 }

--- a/tools/attest/attest.go
+++ b/tools/attest/attest.go
@@ -57,7 +57,9 @@ func outputReport(data [labi.TdReportDataSize]byte, out io.Writer) error {
 		if err != nil {
 			return err
 		}
-		out.Write(bytes)
+		if _, err := out.Write(bytes); err != nil {
+			return err
+		}
 		return nil
 	}
 	quote, err := client.GetQuote(tdxQuoteProvider, data)
@@ -74,7 +76,9 @@ func marshalAndWriteBytes(quote any, out io.Writer) error {
 		if err != nil {
 			return err
 		}
-		out.Write(bytes)
+		if _, err := out.Write(bytes); err != nil {
+			return err
+		}
 		return nil
 	default:
 		return fmt.Errorf("unsupported quote type: %T", quote)


### PR DESCRIPTION
This change updates the ExtendDigestClient function to dynamically support extending Runtime Measurement Register (RTMR) digests on Intel Trust Domain Extensions (TDX) guest systems.

The implementation now checks for the existence of the legacy sysfs rtmr filepath (/sys/kernel/config/ima/rtmr).

If the legacy path is not found, it proceeds to write the digest to the new TDX guest device path (/sys/class/misc/tdx_guest/measurements/rtmr...).

If the legacy path exists, it falls back to the original logic to maintain compatibility.

This allows the same function to work across both old and new versions of kernels by selecting the appropriate method for extending the RTMR.