### PR TITLE
Add verification test for RTMR extension via sysfs

### DIFF
--- a/tools/extend/README.md
+++ b/tools/extend/README.md
@@ -31,6 +31,13 @@ Used to set the verbosity of logger, where higher number means more verbose outp
 
 Default value is `0`.
 
+### `-dev-mode-verify`
+
+This flag enables developer mode to run the RTMR extension verification test suite. This suite performs multiple rounds of measurement extensions and compares 
+the hardware results against software-simulated results to ensure the logic is correct. This flag is intended for debugging and development purposes only. When 
+this flag is used, all other flags are ignored.
+**IMPORTANT**: This operation will pollute the existing RTMR values. To obtain a correct TD Quote after running this command, you **MUST** reboot the VM to reset the RTMRs.
+
 ## Examples
 
 The following example measures an event log and extends its measurement into the RTMR2

--- a/tools/extend/extend.go
+++ b/tools/extend/extend.go
@@ -16,7 +16,11 @@
 package main
 
 import (
+	"bytes"
 	"crypto"
+	"crypto/rand"
+	_ "crypto/sha512" // To get SHA384 recognized by crypto.Hash.
+	"encoding/hex"
 	"flag"
 	"fmt"
 	"io"
@@ -36,6 +40,8 @@ var (
 	quiet     = flag.Bool("quiet", false, "If true, writes nothing the stdout or stderr. Success is exit code 0, failure exit code 1.")
 	verbosity = flag.Int("verbosity", 0, "The output verbosity. Higher number means more verbose output.")
 	index     = flag.Int("rtmr", 2, "The rtmr index. Must be 2 or 3. Defaults to 2.")
+	// Use the dev-mode-verify flag for developer-specific testing of rtmr sysfs interface.
+	devModeVerify = flag.Bool("dev-mode-verify", false, "Enable developer mode to run the RTMR verification test suite. Intended for debugging purposes only.")
 )
 
 func dieWith(err error, exitCode int) {
@@ -68,10 +74,121 @@ func readEventLog() ([]byte, error) {
 	return contents, nil
 }
 
+// runRtmrExtensionTestVerification performs multiple rounds of extending an rtmr and verifies the result.
+// It reads the initial state, performs a hardware extension via the sysfs interface, and compares the new
+// hardware state against a software-simulated extension to ensure they match.
+func runRtmrExtensionTestVerification() {
+	// Define test cases for each RTMR and its corresponding hash algorithm.
+	testCases := []struct {
+		name      string
+		rtmrIndex int
+		hashAlgo  crypto.Hash
+	}{
+		{"RTMR0_SHA384", 0, crypto.SHA384},
+		{"RTMR1_SHA384", 1, crypto.SHA384},
+		{"RTMR2_SHA384", 2, crypto.SHA384},
+		{"RTMR3_SHA384", 3, crypto.SHA384},
+	}
+
+	overallResult := true // Track the overall success of all verification tests.
+
+	fmt.Println("Starting RTMR extension verification...")
+
+	for _, tc := range testCases {
+		fmt.Printf("--- Running verification for %s ---\n", tc.name)
+		filePath := fmt.Sprintf("/sys/class/misc/tdx_guest/measurements/rtmr%d:sha384", tc.rtmrIndex)
+		digestSize := tc.hashAlgo.Size()
+
+		// Check if the sysfs file for the rtmr exists before proceeding.
+		if _, err := os.Stat(filePath); os.IsNotExist(err) {
+			fmt.Printf("Skipping test: RTMR sysfs file not found at %s\n\n", filePath)
+			continue
+		}
+
+		casePassed := true
+		// Run 10 rounds of extend-and-verify for each rtmr to ensure robustness.
+		for i := 0; i < 10; i++ {
+			// 1. Read the initial RTMR value from the sysfs file.
+			initialData, err := os.ReadFile(filePath)
+			if err != nil {
+				fmt.Printf("Round %d: failed to read original digest from %s: %v\n", i+1, filePath, err)
+				os.Exit(1)
+			}
+
+			// 2. Validate the size of the initial data. For a SHA384-based rtmr,
+			// the existing value must be a valid SHA384 digest.
+			if len(initialData) != crypto.SHA384.Size() {
+				fmt.Printf("Round %d: initial data from %s has incorrect size: got %d bytes, want %d bytes\n",
+					i+1, filePath, len(initialData), crypto.SHA384.Size())
+				os.Exit(1)
+			}
+
+			// 3. Start software calculation of the expected measurement.
+			hasher := tc.hashAlgo.New()
+			hasher.Write(initialData)
+
+			// 4. Generate a random event digest to extend into the rtmr.
+			eventDigest := make([]byte, digestSize)
+			if _, err := rand.Read(eventDigest); err != nil {
+				fmt.Printf("Round %d: error generating random data: %v\n", i+1, err)
+				os.Exit(1)
+			}
+
+			hasher.Write(eventDigest)
+			wantDigest := hasher.Sum(nil)
+
+			// 5. Perform the hardware extension by writing the event digest to the sysfs node.
+			if err := rtmr.ExtendDigestSysfs(tc.rtmrIndex, eventDigest); err != nil {
+				fmt.Printf("Round %d: error extending RTMR via sysfs: %v\n", i+1, err)
+				os.Exit(1)
+			}
+
+			// 6. Read the new rtmr value back from the hardware.
+			gotDigest, err := os.ReadFile(filePath)
+			if err != nil {
+				fmt.Printf("Round %d: failed to read back from %s for verification: %v\n", i+1, filePath, err)
+				os.Exit(1)
+			}
+
+			// 7. Compare the software-calculated value with the actual hardware value.
+			if !bytes.Equal(wantDigest, gotDigest) {
+				fmt.Printf("Round %d: VERIFICATION FAILED:\n  Expected: %s\n  Got:      %s\n",
+					i+1, hex.EncodeToString(wantDigest), hex.EncodeToString(gotDigest))
+				overallResult = false
+				casePassed = false
+			} else {
+				fmt.Printf("Round %d: Verification PASSED\n", i+1)
+			}
+		}
+		if casePassed {
+			fmt.Printf("--- All rounds for %s PASSED ---\n\n", tc.name)
+		} else {
+			fmt.Printf("--- Verification for %s FAILED ---\n\n", tc.name)
+		}
+	}
+
+	if overallResult {
+		fmt.Println("=====================================")
+		fmt.Println("✅ All verification test cases passed.")
+		fmt.Println("=====================================")
+		os.Exit(0)
+	} else {
+		fmt.Println("=====================================")
+		fmt.Println("❌ One or more verification tests FAILED.")
+		fmt.Println("=====================================")
+		os.Exit(1)
+	}
+}
+
 func main() {
 	logger.Init("", false, false, os.Stdout)
 	flag.Parse()
 	logger.SetLevel(logger.Level(*verbosity))
+
+	if *devModeVerify {
+		runRtmrExtensionTestVerification()
+		return
+	}
 
 	eventLog, err := readEventLog()
 	if err != nil {


### PR DESCRIPTION
A new test function, TestRtmrExtendVerification, has been added. The test operates in a loop for multiple rounds to ensure consistent and deterministic behavior.

In each round, the test performs the following steps:

1. Reads the initial state of the RTMR from the /sys/class/misc/tdx_guest/measurements/rtmrX:sha384 file.
2. Generates random data to serve as the event for the extension.
3. Calls ExtendDigestSysfs to write the event data to the sysfs file, triggering the hardware extension operation.
4. Performs a software simulation of the extension by hashing the initial RTMR value with the event data.
5. Verifies the result by reading the new RTMR value back from the hardware and asserting that it precisely matches the software-simulated digest.