### PR TITLE
Resolve lint warning by removing redundant else

### DIFF
--- a/tools/extend/extend.go
+++ b/tools/extend/extend.go
@@ -172,12 +172,12 @@ func runRtmrExtensionTestVerification() {
 		fmt.Println("✅ All verification test cases passed.")
 		fmt.Println("=====================================")
 		os.Exit(0)
-	} else {
-		fmt.Println("=====================================")
-		fmt.Println("❌ One or more verification tests FAILED.")
-		fmt.Println("=====================================")
-		os.Exit(1)
 	}
+
+	fmt.Println("=====================================")
+	fmt.Println("❌ One or more verification tests FAILED.")
+	fmt.Println("=====================================")
+	os.Exit(1)
 }
 
 func main() {


### PR DESCRIPTION
In the function runRtmrExtensionTestVerification, the presence of
os.Exit(1) in an 'if' block makes the corresponding 'else'
unnecessary.

Removed the else statement to fix the lint error.