### PR TITLE
Fix documentation for `RootOfTrust.get_collateral`

### DIFF
--- a/proto/checkconfig.proto
+++ b/proto/checkconfig.proto
@@ -69,8 +69,7 @@ message RootOfTrust {
   // If true, download and check the CRL for revoked certificates.
   bool check_crl = 3;
 
-  // If true, then check is not permitted to download necessary files for
-  // verification.
+  // If true, download collateral files for TCB SVN verification.
   bool get_collateral = 4;
 }
 


### PR DESCRIPTION
The description of `RootofTrust.get_collateral` incorrectly claimed that a `true` value prevents fetching collateral when in fact this value gets passed directly into the `Options.GetCollateral` field which (correctly) claims the opposite

https://github.com/google/go-tdx-guest/blob/ffb0869e6f4d355dd34ccfdff8e989c94cf7a59b/verify/verify.go#L1505
https://github.com/google/go-tdx-guest/blob/ffb0869e6f4d355dd34ccfdff8e989c94cf7a59b/verify/verify.go#L183-L184