### PR TITLE
Fix default logger writing os.Stdout to os.Stderr

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -154,5 +154,5 @@ func fallbackToDeviceForRawQuote(reportData [64]byte) ([]uint8, error) {
 }
 
 func init() {
-	logger.Init("", false, false, os.Stdout)
+	logger.Init("", false, false, os.Stderr)
 }


### PR DESCRIPTION
The first call to logger.Init() set up the config, and subsequent calls in other packages simply return the same logger. This library runs init() firstly, which makes our whole project log to stdout by default and won't be able to change that. 