### PR TITLE
Add QuoteV5 support to RTMR extraction and CLI tools

### DIFF
--- a/rtmr/ccel.go
+++ b/rtmr/ccel.go
@@ -37,15 +37,13 @@ type ParseTdxCcelOpts struct {
 	ExtractOpt   extract.Opts
 }
 
-func getRtmrsFromTdQuoteV4(quote *tdxpb.QuoteV4) (*register.RTMRBank, error) {
+func rtmrBankFromSlice(rtmrs [][]byte) (*register.RTMRBank, error) {
 	bank := register.RTMRBank{}
-	rtmrs := quote.TdQuoteBody.Rtmrs
 	for index, rtmr := range rtmrs {
 		bank.RTMRs = append(bank.RTMRs, register.RTMR{
 			Index:  int(index),
 			Digest: rtmr,
 		})
-		// Tdx Quote V4 has a maximum of 4 RTMRs
 		if index > 3 {
 			return nil, fmt.Errorf("too many RTMRs in quote")
 		}
@@ -58,11 +56,9 @@ func getRtmrsFromTdQuoteV4(quote *tdxpb.QuoteV4) (*register.RTMRBank, error) {
 func GetRtmrsFromTdQuote(quote interface{}) (*register.RTMRBank, error) {
 	switch q := quote.(type) {
 	case *tdxpb.QuoteV4:
-		rtmrs, err := getRtmrsFromTdQuoteV4(q)
-		if err != nil {
-			return nil, err
-		}
-		return rtmrs, nil
+		return rtmrBankFromSlice(q.GetTdQuoteBody().GetRtmrs())
+	case *tdxpb.QuoteV5:
+		return rtmrBankFromSlice(q.GetTdQuoteBodyDescriptor().GetTdQuoteBodyV5().GetRtmrs())
 	default:
 		return nil, fmt.Errorf("unsupported quote type: %T", quote)
 	}

--- a/tools/attest/README.md
+++ b/tools/attest/README.md
@@ -1,13 +1,12 @@
 # `attest` CLI tool
 
-This binary is a thin wrapper around the `client` library to gather attestation
-reports in either binary or textproto formats.
+This binary is a thin wrapper around the `client` library to gather TDX quotes
+in either binary or textproto formats.
 
 The tool's input is the intended `REPORT_DATA` contents, which is 64 bytes of
-user-provided data to include in the attestation report. This is typically a
-nonce.
+user-provided data to include in the TDX quote. This is typically a nonce.
 
-The tool's output is the report in any specified format to either standard out
+The tool's output is the TDX quote in any specified format to either standard out
 or directly to a file.
 
 *Note*: For Ubuntu images, the `tdx_guest` module was moved to linux-modules-extra
@@ -34,8 +33,10 @@ sudo modprobe tdx_guest
 
 ### `-in`
 
-This flag provides a string of 64 bytes `REPORT_DATA` content directly on the command line to include in the output attestation report.
-REPORT_DATA can be either in base64 or hex format. If -inform=auto, first check with base64, hex and last with auto.
+This flag provides a string of 64 bytes `REPORT_DATA` content directly on the
+command line to include in the output TDX quote.
+REPORT_DATA can be either in base64 or hex format. If `-inform=auto`, first check
+with base64, hex and last with auto.
 
 ### `-inform`
 
@@ -58,7 +59,7 @@ Default value is `bin`.
 
 ### `-out`
 
-Path to output file to write attestation report to.
+Path to output file to write TDX quote to.
 
 Default is empty, interpreted as stdout.
 

--- a/tools/attest/attest.go
+++ b/tools/attest/attest.go
@@ -80,6 +80,15 @@ func marshalAndWriteBytes(quote any, out io.Writer) error {
 			return err
 		}
 		return nil
+	case *pb.QuoteV5:
+		bytes, err := prototext.Marshal(q)
+		if err != nil {
+			return err
+		}
+		if _, err := out.Write(bytes); err != nil {
+			return err
+		}
+		return nil
 	default:
 		return fmt.Errorf("unsupported quote type: %T", quote)
 	}

--- a/tools/check/README.md
+++ b/tools/check/README.md
@@ -22,8 +22,8 @@ This flag provides the path to the quote to check. Stdin is "-".
 The format that input takes. One of
 
 *   `bin`: for a raw binary quote.
-*   `proto`: A binary serialized `tdx.QuoteV4` message.
-*   `textproto`: The `tdx.QuoteV4` message in textproto format.
+*   `proto`: A binary serialized quote message.
+*   `textproto`: The quote message in textproto format.
 
 Default value is `bin`.
 
@@ -79,4 +79,3 @@ $ ./check -in quote.dat -inform bin -get_collateral -check_crl
 *   2: Failure due to quote parsing errors, invalid signatures, certificates or
  collateral mismatch
 *   3: Failure due to an issue with the network or Intel's PCS
-

--- a/tools/check/check.go
+++ b/tools/check/check.go
@@ -98,6 +98,10 @@ var (
 	reportdata     = cmdline.Bytes("-report_data", abi.ReportDataSize, reportdataS)
 	minteetcbsvnS  = flag.String("minimum_tee_tcb_svn", "", "The minimum acceptable value for TEE_TCB_SVN field as a hex string. Must encode 16 bytes. Unchecked if unset.")
 	minteetcbsvn   = cmdline.Bytes("-minimum_tee_tcb_svn", abi.TeeTcbSvnSize, minteetcbsvnS)
+	minteetcbsvn2S = flag.String("minimum_tee_tcb_svn2", "", "The minimum acceptable value for TEE_TCB_SVN2 field (V5 TDX 1.5 only) as a hex string. Must encode 16 bytes. Unchecked if unset.")
+	minteetcbsvn2  = cmdline.Bytes("-minimum_tee_tcb_svn2", abi.TeeTcbSvn2SizeV5, minteetcbsvn2S)
+	mrservicetdS   = flag.String("mr_service_td", "", "The expected MR_SERVICE_TD field (V5 TDX 1.5 only) as a hex string. Must encode 48 bytes. Unchecked if unset.")
+	mrservicetd    = cmdline.Bytes("-mr_service_td", abi.MrServiceTdSizeV5, mrservicetdS)
 
 	rtmrs = flag.String("rtmrs", "",
 		"Comma-separated hex strings representing expected values of RTMRS field. Expected 4 strings, either empty or each must encode 48 bytes. Unchecked if unset")
@@ -137,17 +141,25 @@ func parseQuote(b []byte) (any, error) {
 	case "bin":
 		return parseQuoteBytes(b)
 	case "proto":
-		result := &pb.QuoteV4{}
-		if err := proto.Unmarshal(b, result); err != nil {
+		resultV4 := &pb.QuoteV4{}
+		if err := proto.Unmarshal(b, resultV4); err == nil && resultV4.GetHeader() != nil {
+			return resultV4, nil
+		}
+		resultV5 := &pb.QuoteV5{}
+		if err := proto.Unmarshal(b, resultV5); err != nil {
 			return nil, fmt.Errorf("could not parse %q as proto: %v", *infile, err)
 		}
-		return result, nil
+		return resultV5, nil
 	case "textproto":
-		result := &pb.QuoteV4{}
-		if err := prototext.Unmarshal(b, result); err != nil {
+		resultV4 := &pb.QuoteV4{}
+		if err := prototext.Unmarshal(b, resultV4); err == nil && resultV4.GetHeader() != nil {
+			return resultV4, nil
+		}
+		resultV5 := &pb.QuoteV5{}
+		if err := prototext.Unmarshal(b, resultV5); err != nil {
 			return nil, fmt.Errorf("could not parse %q as textproto: %v", *infile, err)
 		}
-		return result, nil
+		return resultV5, nil
 	default:
 		return nil, fmt.Errorf("unknown value -inform=%s", *inform)
 	}
@@ -366,6 +378,8 @@ func populateConfig() error {
 	setNonNil(&policy.TdQuoteBodyPolicy.MrOwner, *mrowner)
 	setNonNil(&policy.TdQuoteBodyPolicy.MrOwnerConfig, *mrownerconfig)
 	setNonNil(&policy.TdQuoteBodyPolicy.ReportData, *reportdata)
+	setNonNil(&policy.TdQuoteBodyPolicy.MinimumTeeTcbSvn2, *minteetcbsvn2)
+	setNonNil(&policy.TdQuoteBodyPolicy.MrServiceTd, *mrservicetd)
 
 	return multierr.Combine(
 		setUint32(&policy.HeaderPolicy.MinimumQeSvn, "minimum_qe_svn", *minqesvn, defaultMinQeSvn),

--- a/tools/check/check_test.go
+++ b/tools/check/check_test.go
@@ -65,8 +65,16 @@ func TestMain(m *testing.M) {
 }
 
 func withBaseArgs(config string, args ...string) []string {
+	return withBaseArgsQuote("../../testing/testdata/tdx_prod_quote_SPR_E4.dat", config, args...)
+}
+
+func withBaseArgsV5(config string, args ...string) []string {
+	return withBaseArgsQuote("../../testing/testdata/quote_sample_v5.dat", config, args...)
+}
+
+func withBaseArgsQuote(quotePath, config string, args ...string) []string {
 	base := []string{
-		"-in", "../../testing/testdata/tdx_prod_quote_SPR_E4.dat",
+		"-in", quotePath,
 		"-test_local_getter",
 	}
 
@@ -364,6 +372,93 @@ func TestNetworkFlags(t *testing.T) {
 	cmd := exec.Command(check, withBaseArgs("", fmt.Sprintf("-%s=%s", "check_crl", "true"))...)
 	if output, err := cmd.CombinedOutput(); err == nil {
 		t.Errorf("%s check_crl flag succeeded unexpectedly: %v, %s", cmd, err, output)
+	}
+}
+
+func testCasesV5() []testCase {
+	return []testCase{
+		{
+			flag: "minimum_qe_svn",
+			good: "0",
+			bad: []string{
+				"1",
+			},
+			setter: uint32setter("minimum_qe_svn", "header_policy"),
+		},
+		{
+			flag:   "qe_vendor_id",
+			good:   "939a7233f79c4ca9940a0db3957f0607",
+			bad:    []string{"00000000000000000000000000000001"},
+			setter: bytesSetter("qe_vendor_id", "header_policy"),
+		},
+		{
+			flag:   "minimum_tee_tcb_svn",
+			good:   "0b010400000000000000000000000000",
+			bad:    []string{"0b010400000000000000000000000011"},
+			setter: bytesSetter("minimum_tee_tcb_svn", "td_quote_body_policy"),
+		},
+		{
+			flag: "mr_seam",
+			good: "7bf063280e94fb051f5dd7b1fc59ce9aac42bb961df8d44b709c9b0ff87a7b4df648657ba6d1189589feab1d5a3c9a9d",
+			bad: []string{
+				"7bf063280e94fb051f5dd7b1fc59ce9aac42bb961df8d44b709c9b0ff87a7b4df648657ba6d1189589feab1d5a3c0000"},
+			setter: bytesSetter("mr_seam", "td_quote_body_policy"),
+		},
+		{
+			flag:   "td_attributes",
+			good:   "0000001000000000",
+			bad:    []string{"0000001000000011"},
+			setter: bytesSetter("td_attributes", "td_quote_body_policy"),
+		},
+		{
+			flag: "mr_td",
+			good: "7348651a34b2d2d3462822e3a750ec6110125f36757c78480bbfc69cc0d21fb001a1ced3ee19747dda8f750c3bc8f876",
+			bad: []string{
+				"7348651a34b2d2d3462822e3a750ec6110125f36757c78480bbfc69cc0d21fb001a1ced3ee19747dda8f750c3bc80000"},
+			setter: bytesSetter("mr_td", "td_quote_body_policy"),
+		},
+		{
+			flag:   "report_data",
+			good:   "945eaacf5abc1f719d8666a942fda03d1edcb4490277396093dc5a5289ab9f1e094aed63060cd4a4933a4dd537ed1255c9c79ecb3ed82cd1b486233e31c25c3a",
+			bad:    []string{"945eaacf5abc1f719d8666a942fda03d1edcb4490277396093dc5a5289ab9f1e094aed63060cd4a4933a4dd537ed1255c9c79ecb3ed82cd1b486233e31c20000"},
+			setter: bytesSetter("report_data", "td_quote_body_policy"),
+		},
+		{
+			flag:   "minimum_tee_tcb_svn2",
+			good:   "0d010400000000000000000000000000",
+			bad:    []string{"0d010400000000000000000000000011"},
+			setter: bytesSetter("minimum_tee_tcb_svn2", "td_quote_body_policy"),
+		},
+		{
+			flag:   "mr_service_td",
+			good:   "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+			bad:    []string{"000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000011"},
+			setter: bytesSetter("mr_service_td", "td_quote_body_policy"),
+		},
+	}
+}
+
+func TestCheckGoodFlagsV5(t *testing.T) {
+	for _, tc := range testCasesV5() {
+		t.Run(tc.flag, func(t *testing.T) {
+			cmd := exec.Command(check, withBaseArgsV5("", fmt.Sprintf("-%s=%s", tc.flag, tc.good))...)
+			if output, err := cmd.CombinedOutput(); err != nil {
+				t.Errorf("%s failed unexpectedly: %v (%s)", cmd, err, output)
+			}
+		})
+	}
+}
+
+func TestCheckBadFlagsV5(t *testing.T) {
+	for _, tc := range testCasesV5() {
+		for i, bad := range tc.bad {
+			t.Run(fmt.Sprintf("%s[%d]", tc.flag, i+1), func(t *testing.T) {
+				cmd := exec.Command(check, withBaseArgsV5("", fmt.Sprintf("-%s=%s", tc.flag, bad))...)
+				if output, err := cmd.CombinedOutput(); err == nil {
+					t.Errorf("%s succeeded unexpectedly: %s", cmd, output)
+				}
+			})
+		}
 	}
 }
 


### PR DESCRIPTION
This pull request adds QuoteV5 support in RTMR extraction (`ccel.go`) and CLI tools (`attest` and `check`), updates documentation to clarify terminology and usage for both V4 and V5 quotes (incl. minor terminology corrections), and introduces new flags and tests for V5-specific fields.