### PR TITLE
Add `provenance` command to fetch VM provenance data

### DIFF
--- a/tools/provenance/README.md
+++ b/tools/provenance/README.md
@@ -46,4 +46,4 @@ Path to a raw binary TDX quote file to extract PPID from. The quote must contain
 - `-verbose`: Enable verbose output.
 ## PPID Resolution Order
 
-If neither `-ppid` nor `-quote` is provided, the tool will attempt to fetch a TDX quote from the local system using the Linux TSM interface (`/sys/kernel/config/tsm/report`). This usually requires root privileges (`sudo`).
+If neither `-ppid` nor `-quote` is provided, the tool will attempt to fetch a TDX quote from the local system. This usually requires root privileges (`sudo`).

--- a/tools/provenance/README.md
+++ b/tools/provenance/README.md
@@ -1,0 +1,49 @@
+# `provenance` CLI tool
+
+This tool fetches a JSON file containing GCP machine info/provenance from a public GCS bucket based on a PPID(Platform Provisioning Id).
+
+## Building the Tool
+
+To create the executable, run the following command from the repository root:
+
+```console
+go build ./tools/provenance
+```
+
+This will create a `provenance` executable in your current directory.
+
+Alternatively, you can run the tool directly without building an executable:
+
+```console
+go run ./tools/provenance [options...]
+```
+
+## Usage
+The PPID can be determined in three ways:
+
+### 1. Automatically from the local platform
+Requires running inside a supported Confidential VM with TDX and root privileges (`sudo`):
+```bash
+sudo ./provenance
+```
+
+### 2. Extracted from a TDX Quote file
+Path to a raw binary TDX quote file to extract PPID from. The quote must contain a PCK certificate chain from which the PPID is extracted.
+
+```bash
+./provenance -quote /path/to/quote.bin
+```
+
+### 3. Provided directly via flag
+```bash
+./provenance -ppid <PPID_STRING>
+```
+
+## Optional Flags
+
+- `-bucket`: The public GCS bucket name to fetch the provenance document from.
+- `-out`: Path to output file to write provenance data to. Defaults to stdout.
+- `-verbose`: Enable verbose output.
+## PPID Resolution Order
+
+If neither `-ppid` nor `-quote` is provided, the tool will attempt to fetch a TDX quote from the local system using the Linux TSM interface (`/sys/kernel/config/tsm/report`). This usually requires root privileges (`sudo`).

--- a/tools/provenance/main.go
+++ b/tools/provenance/main.go
@@ -1,0 +1,188 @@
+// Package main implements a CLI tool to fetch provenance data from a GCS bucket using a PPID.
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/google/go-tdx-guest/abi"
+	tg "github.com/google/go-tdx-guest/client"
+	"github.com/google/go-tdx-guest/pcs"
+	"github.com/google/go-tdx-guest/verify"
+)
+
+const gcsBaseURL = "https://storage.googleapis.com"
+
+var (
+	ppidFlag       = flag.String("ppid", "", "Direct PPID string to use")
+	quoteFileFlag  = flag.String("quote", "", "Path to a raw binary TDX quote file to extract PPID from")
+	bucketNameFlag = flag.String("bucket", "gca-placeholder-bucket", "The public GCS bucket name to fetch the provenance document from")
+	outputFlag     = flag.String("out", "", "Path to output file to write provenance data to. Default is stdout.")
+	verboseFlag    = flag.Bool("verbose", false, "Enable verbose output")
+
+	validPPID   = regexp.MustCompile(`^[a-fA-F0-9]{32}$`)
+	validBucket = regexp.MustCompile(`^[a-z0-9_.-]{3,63}$`)
+)
+
+func debugf(format string, a ...any) {
+	if *verboseFlag {
+		fmt.Fprintf(os.Stderr, format, a...)
+	}
+}
+
+// getPPIDFromQuote extracts the PPID from the PCK certificate embedded in the TDX quote.
+// The quote must be in a format that verify.ExtractChainFromQuote can handle (e.g., *pb.Quote or raw bytes).
+func getPPIDFromQuote(quote any) (string, error) {
+	chain, err := verify.ExtractChainFromQuote(quote)
+	if err != nil {
+		return "", fmt.Errorf("could not extract PCK certificate chain from quote: %w", err)
+	}
+	if chain == nil || chain.PCKCertificate == nil {
+		return "", errors.New("PCK certificate is missing in the quote")
+	}
+	exts, err := pcs.PckCertificateExtensions(chain.PCKCertificate)
+	if err != nil {
+		return "", fmt.Errorf("could not extract PCK extensions: %w", err)
+	}
+	if exts.PPID == "" {
+		return "", errors.New("PPID is empty in PCK extensions")
+	}
+	return exts.PPID, nil
+}
+
+func resolvePPID() (string, error) {
+	if *ppidFlag != "" {
+		return *ppidFlag, nil
+	}
+	if *quoteFileFlag != "" {
+		quoteBytes, err := os.ReadFile(*quoteFileFlag)
+		if err != nil {
+			return "", fmt.Errorf("failed to read quote file at %s: %w", *quoteFileFlag, err)
+		}
+		quoteProto, err := abi.QuoteToProto(quoteBytes)
+		if err != nil {
+			return "", fmt.Errorf("failed to parse quote bytes: %w", err)
+		}
+		ppid, err := getPPIDFromQuote(quoteProto)
+		if err != nil {
+			return "", fmt.Errorf("failed to extract PPID from quote file: %w", err)
+		}
+		return ppid, nil
+	}
+
+	qp, err := tg.GetQuoteProvider()
+	if err != nil {
+		return "", fmt.Errorf("failed to get quote provider: %w", err)
+	}
+	if err := qp.IsSupported(); err != nil {
+		return "", fmt.Errorf("tdx quote provider not supported on this platform: %w", err)
+	}
+
+	var tdxNonce [64]byte
+	quote, err := tg.GetQuote(qp, tdxNonce)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch local TDX quote: %w", err)
+	}
+	ppid, err := getPPIDFromQuote(quote)
+	if err != nil {
+		return "", fmt.Errorf("failed to extract PPID from local quote: %w", err)
+	}
+	return ppid, nil
+}
+
+func fetchProvenanceData(baseURL, ppid, bucket string) ([]byte, error) {
+	if !validPPID.MatchString(ppid) {
+		return nil, errors.New("invalid PPID format")
+	}
+	if !validBucket.MatchString(bucket) {
+		return nil, errors.New("invalid bucket name format")
+	}
+
+	debugf("Using PPID: %s\n", ppid)
+	debugf("Using GCS Bucket: %s\n", bucket)
+
+	url := fmt.Sprintf("%s/%s/%s.json", baseURL, bucket, ppid)
+	debugf("Fetching from URL: %s\n", url)
+
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+	}
+	resp, err := client.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch from GCS: %w", err)
+	}
+	defer resp.Body.Close()
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, parseGCSError(resp, bodyBytes, ppid, bucket)
+	}
+
+	if !json.Valid(bodyBytes) {
+		return nil, errors.New("received invalid JSON from GCS")
+	}
+
+	return bodyBytes, nil
+}
+
+func parseGCSError(resp *http.Response, bodyBytes []byte, ppid string, bucket string) error {
+	bodyStr := string(bodyBytes)
+	if strings.Contains(bodyStr, "NoSuchBucket") {
+		return fmt.Errorf("gcs request failed: bucket '%s' not found", bucket)
+	}
+	if strings.Contains(bodyStr, "NoSuchKey") {
+		return fmt.Errorf("gcs request failed: file '%s.json' not found in bucket '%s'", ppid, bucket)
+	}
+	if resp.StatusCode == http.StatusForbidden {
+		return fmt.Errorf("gcs request failed: access denied to bucket '%s' (403 Forbidden); the bucket may be private or not exist", bucket)
+	}
+	return fmt.Errorf("gcs request failed with status: %s", resp.Status)
+}
+
+func run(baseURL string) error {
+	ppid, err := resolvePPID()
+	if err != nil {
+		return err
+	}
+
+	bodyBytes, err := fetchProvenanceData(baseURL, ppid, *bucketNameFlag)
+	if err != nil {
+		return err
+	}
+
+	out := os.Stdout
+	if *outputFlag != "" {
+		f, err := os.Create(*outputFlag)
+		if err != nil {
+			return fmt.Errorf("failed to create output file: %w", err)
+		}
+		defer f.Close()
+		out = f
+	}
+
+	if _, err := out.Write(bodyBytes); err != nil {
+		return fmt.Errorf("failed to write output: %w", err)
+	}
+
+	return nil
+}
+
+func main() {
+	flag.Parse()
+	if err := run(gcsBaseURL); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/tools/provenance/main.go
+++ b/tools/provenance/main.go
@@ -22,7 +22,7 @@ import (
 const gcsBaseURL = "https://storage.googleapis.com"
 
 var (
-	ppidFlag       = flag.String("ppid", "", "Direct PPID string to use")
+	ppidFlag       = flag.String("ppid", "", "PPID as a 32-character hex string")
 	quoteFileFlag  = flag.String("quote", "", "Path to a raw binary TDX quote file to extract PPID from")
 	bucketNameFlag = flag.String("bucket", "gca-placeholder-bucket", "The public GCS bucket name to fetch the provenance document from")
 	outputFlag     = flag.String("out", "", "Path to output file to write provenance data to. Default is stdout.")
@@ -39,7 +39,8 @@ func debugf(format string, a ...any) {
 }
 
 // getPPIDFromQuote extracts the PPID from the PCK certificate embedded in the TDX quote.
-// The quote must be in a format that verify.ExtractChainFromQuote can handle (e.g., *pb.Quote or raw bytes).
+// The quote must be a proto type accepted by verify.ExtractChainFromQuote (*pb.QuoteV4 or *pb.QuoteV5);
+// raw bytes must be parsed via abi.QuoteToProto first.
 func getPPIDFromQuote(quote any) (string, error) {
 	chain, err := verify.ExtractChainFromQuote(quote)
 	if err != nil {

--- a/tools/provenance/main_test.go
+++ b/tools/provenance/main_test.go
@@ -30,18 +30,18 @@ func TestProvenance(t *testing.T) {
 		{
 			name:           "No Such Bucket",
 			ppid:           "abcdef1234567890abcdef1234567890",
-			bucket:         "test-bucket",
+			bucket:         "missing-bucket",
 			serverResponse: "NoSuchBucket",
 			serverStatus:   http.StatusNotFound,
-			wantErr:        "gcs request failed: bucket 'test-bucket' not found",
+			wantErr:        "gcs request failed: bucket 'missing-bucket' not found",
 		},
 		{
 			name:           "No Such Key",
-			ppid:           "abcdef1234567890abcdef1234567890",
+			ppid:           "0000000000000000000000000000000a",
 			bucket:         "test-bucket",
 			serverResponse: "NoSuchKey",
 			serverStatus:   http.StatusNotFound,
-			wantErr:        "gcs request failed: file 'abcdef1234567890abcdef1234567890.json' not found in bucket 'test-bucket'",
+			wantErr:        "gcs request failed: file '0000000000000000000000000000000a.json' not found in bucket 'test-bucket'",
 		},
 		{
 			name:           "Server Error",

--- a/tools/provenance/main_test.go
+++ b/tools/provenance/main_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestProvenance(t *testing.T) {
+	tests := []struct {
+		name           string
+		ppid           string
+		bucket         string
+		serverResponse string
+		serverStatus   int
+		validOutput    bool
+		wantErr        string
+	}{
+		{
+			name:           "Direct PPID Success",
+			ppid:           "abcdef1234567890abcdef1234567890",
+			bucket:         "test-bucket",
+			serverResponse: `{"location": "us-east1"}`,
+			serverStatus:   http.StatusOK,
+			validOutput:    true,
+		},
+		{
+			name:           "No Such Bucket",
+			ppid:           "abcdef1234567890abcdef1234567890",
+			bucket:         "test-bucket",
+			serverResponse: "NoSuchBucket",
+			serverStatus:   http.StatusNotFound,
+			wantErr:        "gcs request failed: bucket 'test-bucket' not found",
+		},
+		{
+			name:           "No Such Key",
+			ppid:           "abcdef1234567890abcdef1234567890",
+			bucket:         "test-bucket",
+			serverResponse: "NoSuchKey",
+			serverStatus:   http.StatusNotFound,
+			wantErr:        "gcs request failed: file 'abcdef1234567890abcdef1234567890.json' not found in bucket 'test-bucket'",
+		},
+		{
+			name:           "Server Error",
+			ppid:           "abcdef1234567890abcdef1234567890",
+			bucket:         "test-bucket",
+			serverResponse: "internal error",
+			serverStatus:   http.StatusInternalServerError,
+			wantErr:        "gcs request failed with status: 500 Internal Server Error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				expectedPath := fmt.Sprintf("/%s/%s.json", tt.bucket, tt.ppid)
+				if r.URL.Path != expectedPath {
+					t.Errorf("expected path %q, got %q", expectedPath, r.URL.Path)
+					http.Error(w, "not found", http.StatusNotFound)
+					return
+				}
+				w.WriteHeader(tt.serverStatus)
+				fmt.Fprint(w, tt.serverResponse)
+			}))
+			defer ts.Close()
+
+			oldPpid := *ppidFlag
+			oldBucket := *bucketNameFlag
+			oldOut := *outputFlag
+			t.Cleanup(func() {
+				*ppidFlag = oldPpid
+				*bucketNameFlag = oldBucket
+				*outputFlag = oldOut
+			})
+
+			*ppidFlag = tt.ppid
+			*bucketNameFlag = tt.bucket
+
+			outFile := filepath.Join(t.TempDir(), "output.json")
+			*outputFlag = outFile
+
+			err := run(ts.URL)
+
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if err.Error() != tt.wantErr {
+					t.Errorf("expected error %q, got %q", tt.wantErr, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("run failed: %v", err)
+				}
+				if tt.validOutput {
+					b, err := os.ReadFile(outFile)
+					if err != nil {
+						t.Fatalf("failed to read output file: %v", err)
+					}
+					if string(b) != tt.serverResponse {
+						t.Errorf("expected %s, got %s", tt.serverResponse, string(b))
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
The `provenance` command fetches a JSON file containing machine info/provenance from a public GCS bucket based on a PPID. The PPID can be provided explicitly, extracted from a TDX quote file, or obtained by fetching a quote from the currently running TDX CVM.

## Usage
The PPID can be determined in three ways:

### 1. Automatically from the local platform
Requires running inside a supported Confidential VM with TDX and root privileges (`sudo`):
```bash
sudo ./provenance
```

### 2. Extracted from a TDX Quote file
Path to a raw binary TDX quote file to extract PPID from. The quote must contain a PCK certificate chain from which the PPID is extracted.

```bash
./provenance -quote /path/to/quote.bin
```

### 3. Provided directly via flag
```bash
./provenance -ppid <PPID_STRING>
```