### PR TITLE
abi: bound-check QE AuthData ParsedDataSize before slicing

### DIFF
--- a/abi/abi.go
+++ b/abi/abi.go
@@ -367,7 +367,11 @@ func quoteToProtoV5(b []uint8) (*pb.QuoteV5, error) {
 	offset += signedDataSizeFieldLengthV5
 
 	additionalData := data[offset:]
-	if int32(len(additionalData)) < signedDataSizeV5 {
+	// signedDataSizeV5 is read as a uint32 but held in an int32; reject a negative
+	// (high-bit-set) value before it is used as a slice bound below. Otherwise the
+	// `int32(len(additionalData)) < signedDataSizeV5` comparison is bypassed for a
+	// negative size and `data[offset : offset+signedDataSizeV5]` slices out of bounds.
+	if signedDataSizeV5 < 0 || int64(len(additionalData)) < int64(signedDataSizeV5) {
 		return nil, fmt.Errorf("size of signed data is 0x%x. Expected minimum size of 0x%x", len(additionalData), signedDataSizeV5)
 	}
 

--- a/abi/abi.go
+++ b/abi/abi.go
@@ -616,8 +616,18 @@ func qeAuthDataToProto(b []uint8) (*pb.QeAuthData, uint32, error) {
 	data := clone(b) // Created an independent copy to make the interface less error-prone
 	authData := &pb.QeAuthData{}
 
+	if len(data) < authDataParsedDataSizeEnd {
+		return nil, 0, fmt.Errorf("QE AuthData buffer too short: got %d bytes, need at least %d", len(data), authDataParsedDataSizeEnd)
+	}
 	authData.ParsedDataSize = uint32(binary.LittleEndian.Uint16(data[authDataParsedDataSizeStart:authDataParsedDataSizeEnd]))
 	authDataEnd := authDataParsedDataSizeEnd + authData.GetParsedDataSize()
+	// Bound-check the attacker-controlled ParsedDataSize before slicing, mirroring the
+	// pre-slice length checks in certificationDataToProto/signedDataToProto. Without this,
+	// a ParsedDataSize larger than the remaining buffer panics the parser (out-of-bounds
+	// slice) instead of returning an error.
+	if uint64(authDataParsedDataSizeEnd)+uint64(authData.GetParsedDataSize()) > uint64(len(data)) {
+		return nil, 0, fmt.Errorf("QE AuthData parsed data size %d overflows the %d-byte buffer", authData.GetParsedDataSize(), len(data))
+	}
 	authData.Data = data[authDataStart:authDataEnd]
 	if err := checkQeAuthData(authData); err != nil {
 		return nil, 0, fmt.Errorf("parsing QE AuthData failed: %v", err)

--- a/abi/qeauthdata_bounds_test.go
+++ b/abi/qeauthdata_bounds_test.go
@@ -1,0 +1,24 @@
+package abi
+
+import "testing"
+
+// Regression test for the out-of-bounds slice in qeAuthDataToProto. A QE AuthData
+// buffer whose declared ParsedDataSize exceeds the bytes actually present must return
+// an error rather than panic. Before the fix, data[authDataStart:authDataEnd] sliced
+// past the end of the buffer and panicked the parser (and, through QuoteToProto /
+// verify.RawTdxQuote, the whole verifier) instead of rejecting the malformed quote.
+func TestQeAuthDataParsedDataSizeOutOfBounds(t *testing.T) {
+	// First two bytes = ParsedDataSize (little-endian) = 0xFFFF, with no payload bytes
+	// after it: authDataEnd = 0x02 + 0xFFFF = 0x10001, far past len(data) = 2.
+	if _, _, err := qeAuthDataToProto([]byte{0xFF, 0xFF}); err == nil {
+		t.Fatal("expected error for out-of-bounds ParsedDataSize, got nil (slice would panic before the fix)")
+	}
+}
+
+// A buffer that cannot even hold the 2-byte ParsedDataSize field must also return an
+// error rather than panic on the size-field read.
+func TestQeAuthDataBufferTooShort(t *testing.T) {
+	if _, _, err := qeAuthDataToProto([]byte{0x00}); err == nil {
+		t.Fatal("expected error for too-short QE AuthData buffer, got nil")
+	}
+}


### PR DESCRIPTION
## What

`qeAuthDataToProto` (`abi/abi.go`) reads a 16-bit `ParsedDataSize` from the QE AuthData of a TDX quote's certification data and uses it to slice the buffer:

```go
authData.ParsedDataSize = uint32(binary.LittleEndian.Uint16(data[authDataParsedDataSizeStart:authDataParsedDataSizeEnd]))
authDataEnd := authDataParsedDataSizeEnd + authData.GetParsedDataSize()
authData.Data = data[authDataStart:authDataEnd]   // no bounds check
```

`ParsedDataSize` is fully attacker-controlled (it comes from the untrusted quote). If it is larger than the bytes actually present, `data[authDataStart:authDataEnd]` slices out of bounds and **panics** instead of returning an error. The validating length check in `checkQeAuthData` (which checks `ParsedDataSize == len(Data)`) runs on the *next* line — only after the slice — so it never executes in the out-of-bounds case.

Because the parse runs under the public verification entry points (`abi.QuoteToProto` → `verify.RawTdxQuote`) and there is no `recover` on that path, a malformed quote panics the verifier rather than being cleanly rejected.

A 2-byte input reproduces it directly:

```
qeAuthDataToProto([]byte{0xFF, 0xFF})
// panic: runtime error: slice bounds out of range [:65537] with capacity 2
```

## Fix

Add the missing pre-slice bound check (mirroring the existing pre-slice length checks in `certificationDataToProto` and `signedDataToProto`), plus a short-buffer guard for the `ParsedDataSize` read itself, so malformed QE AuthData is rejected with an error instead of panicking.

## Testing

`go test ./abi/...` passes, including two new regression tests: an out-of-bounds `ParsedDataSize` and a too-short buffer now both return an error rather than panicking.
