### PR TITLE
Add boundary checks and unit tests to abi package

### DIFF
--- a/abi/abi.go
+++ b/abi/abi.go
@@ -317,7 +317,7 @@ func quoteToProtoV4(b []uint8) (*pb.QuoteV4, error) {
 	quote.SignedDataSize = binary.LittleEndian.Uint32(data[quoteSignedDataSizeStart:quoteSignedDataSizeEnd])
 
 	additionalData := data[quoteSignedDataStart:]
-	if uint32(len(additionalData)) < quote.GetSignedDataSize() {
+	if uint64(len(additionalData)) < uint64(quote.GetSignedDataSize()) {
 		return nil, fmt.Errorf("size of signed data is 0x%x. Expected minimum size of 0x%x", len(additionalData), quote.GetSignedDataSize())
 	}
 	quoteSignedDataEnd := quoteSignedDataStart + quote.GetSignedDataSize()
@@ -367,7 +367,10 @@ func quoteToProtoV5(b []uint8) (*pb.QuoteV5, error) {
 	offset += signedDataSizeFieldLengthV5
 
 	additionalData := data[offset:]
-	if int32(len(additionalData)) < signedDataSizeV5 {
+	if signedDataSizeV5 < 0 {
+		return nil, fmt.Errorf("signed data size %d is negative", signedDataSizeV5)
+	}
+	if int64(len(additionalData)) < int64(signedDataSizeV5) {
 		return nil, fmt.Errorf("size of signed data is 0x%x. Expected minimum size of 0x%x", len(additionalData), signedDataSizeV5)
 	}
 
@@ -395,6 +398,9 @@ func quoteToProtoV5(b []uint8) (*pb.QuoteV5, error) {
 
 func headerToProto(b []uint8) (*pb.Header, error) {
 	data := clone(b) // Created an independent copy to make the interface less error-prone
+	if len(data) != headerSize {
+		return nil, fmt.Errorf("header size is %d bytes. Expected %d bytes", len(data), headerSize)
+	}
 	header := &pb.Header{}
 
 	quoteVersion := uint32(binary.LittleEndian.Uint16(data[headerVersionStart:headerVersionEnd]))
@@ -417,6 +423,9 @@ func headerToProto(b []uint8) (*pb.Header, error) {
 
 func tdQuoteBodyToProto(b []uint8) (*pb.TDQuoteBody, error) {
 	data := clone(b) // Created an independent copy to make the interface less error-prone
+	if len(data) != tdQuoteBodySize {
+		return nil, fmt.Errorf("td quote body size is %d bytes. Expected %d bytes", len(data), tdQuoteBodySize)
+	}
 	report := &pb.TDQuoteBody{}
 	report.TeeTcbSvn = data[tdTeeTcbSvnStart:tdTeeTcbSvnEnd]
 	report.MrSeam = data[tdMrSeamStart:tdMrSeamEnd]
@@ -445,8 +454,10 @@ func tdQuoteBodyToProto(b []uint8) (*pb.TDQuoteBody, error) {
 }
 
 func tdQuoteBodyDescriptorToProto(b []uint8) (*pb.TDQuoteBodyDescriptor, int32, error) {
-
 	data := clone(b) // Created an independent copy to make the interface less error-prone
+	if len(data) < quoteBodyTypeSizeV5+quoteBodySizeFieldLengthV5 {
+		return nil, 0, fmt.Errorf("td quote body descriptor size is %d bytes. Expected at least %d bytes", len(data), quoteBodyTypeSizeV5+quoteBodySizeFieldLengthV5)
+	}
 	var offset int32
 
 	tdQuoteBodyDescriptor := &pb.TDQuoteBodyDescriptor{}
@@ -459,6 +470,12 @@ func tdQuoteBodyDescriptorToProto(b []uint8) (*pb.TDQuoteBodyDescriptor, int32, 
 	}
 	if tdQuoteBodyDescriptor.TdQuoteBodyType == tdxVersion15BodyType && tdQuoteBodyDescriptor.TdQuoteBodySize != tdQuoteBodySizeV5TDX15 {
 		return nil, 0, fmt.Errorf("TD quote body size is %d, a V5 TDX1.5 quote should have size %d", tdQuoteBodyDescriptor.TdQuoteBodySize, tdQuoteBodySizeV5TDX15)
+	}
+	if tdQuoteBodyDescriptor.TdQuoteBodyType != tdxVersion10BodyType && tdQuoteBodyDescriptor.TdQuoteBodyType != tdxVersion15BodyType {
+		return nil, 0, fmt.Errorf("parsing TD Quote Body Descriptor failed: unsupported TD quote body type , got %d", tdQuoteBodyDescriptor.TdQuoteBodyType)
+	}
+	if len(data) < quoteBodyTypeSizeV5+quoteBodySizeFieldLengthV5+int(tdQuoteBodyDescriptor.TdQuoteBodySize) {
+		return nil, 0, fmt.Errorf("td quote body descriptor size is %d bytes. Expected %d bytes", len(data), quoteBodyTypeSizeV5+quoteBodySizeFieldLengthV5+int(tdQuoteBodyDescriptor.TdQuoteBodySize))
 	}
 	offset += quoteBodySizeFieldLengthV5
 	tdQuoteBodyV5.TeeTcbSvn = data[offset : offset+teeTcbSvnSizeV5]
@@ -514,6 +531,9 @@ func tdQuoteBodyDescriptorToProto(b []uint8) (*pb.TDQuoteBodyDescriptor, int32, 
 
 func signedDataToProto(b []uint8) (*pb.Ecdsa256BitQuoteV4AuthData, error) {
 	data := clone(b) // Created an independent copy to make the interface less error-prone
+	if len(data) < quoteV4AuthDataKnownSize {
+		return nil, fmt.Errorf("signed data size is %d bytes. Expected at least %d bytes", len(data), quoteV4AuthDataKnownSize)
+	}
 	signedData := &pb.Ecdsa256BitQuoteV4AuthData{}
 	signedData.Signature = data[signedDataSignatureStart:signedDataSignatureEnd]
 	signedData.EcdsaAttestationKey = data[signedDataAttestationKeyStart:signedDataAttestationKeyEnd]
@@ -533,12 +553,15 @@ func signedDataToProto(b []uint8) (*pb.Ecdsa256BitQuoteV4AuthData, error) {
 
 func certificationDataToProto(b []uint8) (*pb.CertificationData, error) {
 	data := clone(b) // Created an independent copy to make the interface less error-prone
+	if len(data) < certificationDataKnownSize {
+		return nil, fmt.Errorf("certification data size is %d bytes. Expected at least %d bytes", len(data), certificationDataKnownSize)
+	}
 	certification := &pb.CertificationData{}
 
 	certification.CertificateDataType = uint32(binary.LittleEndian.Uint16(data[certificateDataTypeStart:certificateDataTypeEnd]))
 	certification.Size = binary.LittleEndian.Uint32(data[certificateSizeStart:certificateSizeEnd])
 	rawCertificateData := data[certificateDataStart:]
-	if uint32(len(rawCertificateData)) != certification.GetSize() {
+	if uint64(len(rawCertificateData)) != uint64(certification.GetSize()) {
 		return nil, fmt.Errorf("size of certificate data is 0x%x. Expected size 0x%x", len(rawCertificateData), certification.GetSize())
 	}
 
@@ -557,6 +580,9 @@ func certificationDataToProto(b []uint8) (*pb.CertificationData, error) {
 
 func qeReportCertificationDataToProto(b []uint8) (*pb.QEReportCertificationData, error) {
 	data := clone(b) // Created an independent copy to make the interface less error-prone
+	if len(data) < qeReportCertificationDataSignatureEnd {
+		return nil, fmt.Errorf("QE report certification data size is %d bytes. Expected at least %d bytes", len(data), qeReportCertificationDataSignatureEnd)
+	}
 	qeReportCertificationData := &pb.QEReportCertificationData{}
 
 	enclaveReport, err := enclaveReportToProto(data[enclaveReportStart:enclaveReportEnd])
@@ -591,6 +617,9 @@ func qeReportCertificationDataToProto(b []uint8) (*pb.QEReportCertificationData,
 
 func enclaveReportToProto(b []uint8) (*pb.EnclaveReport, error) {
 	data := clone(b) // Created an independent copy to make the interface less error-prone
+	if len(data) != qeReportSize {
+		return nil, fmt.Errorf("enclave report size is %d bytes. Expected %d bytes", len(data), qeReportSize)
+	}
 	enclaveReport := &pb.EnclaveReport{}
 
 	enclaveReport.CpuSvn = data[qeCPUSvnStart:qeCPUSvnEnd]
@@ -614,10 +643,16 @@ func enclaveReportToProto(b []uint8) (*pb.EnclaveReport, error) {
 
 func qeAuthDataToProto(b []uint8) (*pb.QeAuthData, uint32, error) {
 	data := clone(b) // Created an independent copy to make the interface less error-prone
+	if len(data) < qeAuthDataKnownSize {
+		return nil, 0, fmt.Errorf("QE auth data size is %d bytes. Expected at least %d bytes", len(data), qeAuthDataKnownSize)
+	}
 	authData := &pb.QeAuthData{}
 
 	authData.ParsedDataSize = uint32(binary.LittleEndian.Uint16(data[authDataParsedDataSizeStart:authDataParsedDataSizeEnd]))
 	authDataEnd := authDataParsedDataSizeEnd + authData.GetParsedDataSize()
+	if uint64(len(data)) < uint64(authDataEnd) {
+		return nil, 0, fmt.Errorf("QE auth data size is %d bytes. Expected %d bytes", len(data), authDataEnd)
+	}
 	authData.Data = data[authDataStart:authDataEnd]
 	if err := checkQeAuthData(authData); err != nil {
 		return nil, 0, fmt.Errorf("parsing QE AuthData failed: %v", err)
@@ -627,6 +662,9 @@ func qeAuthDataToProto(b []uint8) (*pb.QeAuthData, uint32, error) {
 
 func pckCertificateChainToProto(b []uint8) (*pb.PCKCertificateChainData, error) {
 	data := clone(b) // Created an independent copy to make the interface less error-prone
+	if len(data) < pckCertificateChainKnownSize {
+		return nil, fmt.Errorf("PCK certificate chain size is %d bytes. Expected at least %d bytes", len(data), pckCertificateChainKnownSize)
+	}
 	pckCertificateChain := &pb.PCKCertificateChainData{}
 
 	pckCertificateChain.CertificateDataType = uint32(binary.LittleEndian.Uint16(data[pckCertChainCertificationDataTypeStart:pckCertChainCertificationDataTypeEnd]))
@@ -782,7 +820,7 @@ func checkPCKCertificateChain(chain *pb.PCKCertificateChainData) error {
 	if chain.GetCertificateDataType() != pckReportCertificationDataType {
 		return fmt.Errorf("PCK certificate chain data type invalid, got %d, expected %d", chain.GetCertificateDataType(), pckReportCertificationDataType)
 	}
-	if chain.GetSize() != uint32(len(chain.GetPckCertChain())) {
+	if uint64(chain.GetSize()) != uint64(len(chain.GetPckCertChain())) {
 		return fmt.Errorf("PCK certificate chain size is %d. Expected size %d", len(chain.GetPckCertChain()), chain.GetSize())
 	}
 	return nil

--- a/abi/abi_test.go
+++ b/abi/abi_test.go
@@ -86,6 +86,123 @@ func TestQuoteToProto(t *testing.T) {
 			}(),
 			wantErr: "TD quote body size is 648, a V5 TDX1.0 quote should have size 584",
 		},
+		{
+			name:     "quote too small to determine format",
+			rawQuote: []byte{1},
+			wantErr:  "unable to determine quote format since bytes length is less than 2 bytes",
+		},
+		{
+			name:     "v4 quote too small",
+			rawQuote: test.RawQuote[:100],
+			wantErr:  "raw quote size is 0x64, a TDX quote should have size a minimum size of 0x3fc",
+		},
+		{
+			name: "v4 quote signed data size too large",
+			rawQuote: func() []byte {
+				q := clone(test.RawQuote)
+				// SignedDataSize is at 0x278 (632)
+				binary.LittleEndian.PutUint32(q[0x278:0x27C], 0xffffffff)
+				return q
+			}(),
+			wantErr: "size of signed data is 0x10f2. Expected minimum size of 0xffffffff",
+		},
+		{
+			name: "v5 quote signed data size too large",
+			rawQuote: func() []byte {
+				q := clone(test.RawQuoteV5)
+				// In test.RawQuoteV5, it is TDX1.5, so body size is 648.
+				// Header (48) + Descriptor (654) = 702.
+				// SignedDataSize is at 702.
+				binary.LittleEndian.PutUint32(q[702:706], 0x7fffffff)
+				return q
+			}(),
+			wantErr: "size of signed data is 0x10cc. Expected minimum size of 0x7fffffff",
+		},
+		{
+			name: "v5 quote signed data size negative",
+			rawQuote: func() []byte {
+				q := clone(test.RawQuoteV5)
+				// SignedDataSize is at 702.
+				binary.LittleEndian.PutUint32(q[702:706], 0xffffffff) // -1 as int32
+				return q
+			}(),
+			wantErr: "signed data size -1 is negative",
+		},
+		{
+			name: "v4 quote invalid TEE type in header",
+			rawQuote: func() []byte {
+				q := clone(test.RawQuote)
+				// TeeType is at 4 to 8 in header
+				binary.LittleEndian.PutUint32(q[4:8], 0)
+				return q
+			}(),
+			wantErr: "parsing header failed: TEE type is not TDX",
+		},
+		{
+			name: "v4 quote signed data size too small for auth data",
+			rawQuote: func() []byte {
+				q := clone(test.RawQuote)
+				// SignedDataSize is at 0x278 (632)
+				binary.LittleEndian.PutUint32(q[0x278:0x27C], 100)
+				return q
+			}(),
+			wantErr: "signed data size is 100 bytes. Expected at least 128 bytes",
+		},
+		{
+			name: "v4 quote signed data size too small for cert data",
+			rawQuote: func() []byte {
+				q := clone(test.RawQuote)
+				// SignedDataSize is at 0x278 (632)
+				binary.LittleEndian.PutUint32(q[0x278:0x27C], 130)
+				return q
+			}(),
+			wantErr: "certification data size is 2 bytes. Expected at least 6 bytes",
+		},
+		{
+			name: "v4 quote invalid certification data type",
+			rawQuote: func() []byte {
+				q := clone(test.RawQuote)
+				// Certification data starts at 636 + 128 = 764.
+				// CertificateDataType is at 764:766. Set to 5.
+				binary.LittleEndian.PutUint16(q[764:766], 5)
+				return q
+			}(),
+			wantErr: "parsing certification data failed: certification data type invalid, got 5, expected 6",
+		},
+		{
+			name: "v4 quote rawCertificateData too small for QE report",
+			rawQuote: func() []byte {
+				q := clone(test.RawQuote)
+				// SignedDataSize is at 0x278 (632). Set to 128 + 6 + 400 = 534.
+				binary.LittleEndian.PutUint32(q[0x278:0x27C], 534)
+				// Size field in cert data is at 766:770. Set to 400.
+				binary.LittleEndian.PutUint32(q[766:770], 400)
+				return q
+			}(),
+			wantErr: "QE report certification data size is 400 bytes. Expected at least 448 bytes",
+		},
+		{
+			name: "v4 quote QE auth data too small",
+			rawQuote: func() []byte {
+				q := clone(test.RawQuote)
+				// SignedDataSize is at 0x278 (632). Set to 128 + 6 + 449 = 583.
+				binary.LittleEndian.PutUint32(q[0x278:0x27C], 583)
+				// Size field in cert data is at 766:770. Set to 449.
+				binary.LittleEndian.PutUint32(q[766:770], 449)
+				return q
+			}(),
+			wantErr: "QE auth data size is 1 bytes. Expected at least 2 bytes",
+		},
+		{
+			name: "v4 quote QE auth data parsed size mismatch",
+			rawQuote: func() []byte {
+				q := clone(test.RawQuote)
+				// Modify ParsedDataSize at 1218:1220 to 4000.
+				binary.LittleEndian.PutUint16(q[1218:1220], 4000)
+				return q
+			}(),
+			wantErr: "QE auth data size is 3717 bytes. Expected 4002 bytes",
+		},
 	}
 
 	for _, tc := range tcs {


### PR DESCRIPTION
This PR adds robust boundary checks and size validations to the `abi` package to prevent potential out-of-bounds panics and integer truncation/overflow vulnerabilities when parsing untrusted TDX attestation quotes.

Previously, several internal helper functions in `abi/abi.go` sliced input byte arrays using hardcoded offsets without verifying if the input slice was large enough. This could lead to runtime panics if an attacker provided a malformed or truncated quote.

## Changes

### 1. Boundary Checks (`abi/abi.go`)
Added explicit slice length validation at the entry point of all internal parsing helpers before any slicing or reading operation occurs:
* **`headerToProto`**: Verifies input is equal to `headerSize` (48 bytes).
* **`tdQuoteBodyToProto`**: Verifies input is equal to `tdQuoteBodySize` (584 bytes).
* **`tdQuoteBodyDescriptorToProto`**: 
  - Verifies input is at least large enough to read the descriptor type and size (6 bytes).
  - Validates `TdQuoteBodyType` early to fail safely on unsupported types before parsing.
  - Verifies the input slice is at least as large as the descriptor's specified `TdQuoteBodySize`.
* **`signedDataToProto`**: Verifies input is at least `quoteV4AuthDataKnownSize` (128 bytes).
* **`certificationDataToProto`**: Verifies input is at least `certificationDataKnownSize` (6 bytes).
* **`qeReportCertificationDataToProto`**: Verifies input is at least `qeReportCertificationDataSignatureEnd` (448 bytes).
* **`enclaveReportToProto`**: Verifies input is at least `qeReportSize` (384 bytes).
* **`qeAuthDataToProto`**: Verifies input is at least `qeAuthDataKnownSize` (2 bytes) and as large as the parsed `authDataEnd` payload.
* **`pckCertificateChainToProto`**: Verifies input is at least `pckCertificateChainKnownSize` (6 bytes).

### 2. Safe Integer Comparisons
Updated size comparisons to use `uint64` or `int64` instead of downcasting to `uint32` or `int32` to prevent potential integer truncation or overflow vulnerabilities when checking untrusted size fields in:
* **`quoteToProtoV4`** (validating `SignedDataSize`)
* **`quoteToProtoV5`** (validating `signedDataSizeV5` and checking for negative sizes)
* **`certificationDataToProto`** (validating cert size)
* **`checkPCKCertificateChain`** (validating cert chain size)

---

### 3. Comprehensive Unit Tests (`abi/abi_test.go`)
Added 7 new targeted edge case tests to `TestQuoteToProto` to ensure all new boundary and size checks are thoroughly validated:
* **`quote too small to determine format`**: Verifies rejection of slices smaller than the 2-byte version header.
* **`v4 quote too small`**: Verifies rejection of V4 quotes smaller than `QuoteMinSize` (1020 bytes).
* **`v4 quote signed data size too large`**: Verifies rejection when `SignedDataSize` is set to `0xffffffff` (exceeding remaining bytes).
* **`v5 quote signed data size too large`**: Verifies rejection when V5 signed data size exceeds remaining bytes.
* **`v5 quote signed data size negative`**: Verifies rejection when V5 signed data size is negative (MSB set, e.g., `0xffffffff`).
* **`v4 quote invalid TEE type in header`**: Verifies rejection of quotes with an invalid `TeeType` in the header.
* **`v4 quote signed data size too small for auth data`**: Verifies rejection when the signed data size is smaller than the minimum required for signature and key (128 bytes).
* **`v4 quote signed data size too small for cert data`**: Verifies rejection when the signed data size leaves insufficient bytes for the certification data header.
* **`v4 quote invalid certification data type`**: Verifies rejection of unsupported certification data types.
* **`v4 quote rawCertificateData too small for QE report`**: Verifies rejection when the remaining bytes are too small to contain a valid QE report.
* **`v4 quote QE auth data too small`**: Verifies rejection when remaining bytes are insufficient to hold the QE auth data header.
* **`v4 quote QE auth data parsed size mismatch`**: Verifies rejection when the QE auth data's `ParsedDataSize` field is modified to exceed the actual remaining bytes.

---

## How was this tested?

**Unit Tests**: Ran `go test ./...` in the workspace. All tests (including the new boundary check tests) passed successfully.
**E2E tests**: Ran attest and check CLI in a prod TDX CVM, TDX verification successfully passed.