### PR TITLE
Add option making tcbStatus check optional

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - 1.22.x
+          - 1.21.x
         os:
           - macos-latest
           - ubuntu-latest
@@ -53,15 +53,25 @@ jobs:
       - name: Generate all protobufs
         run: go generate ./...
       - name: Build all packages
-        run: go build -v ./...
+        run: |
+          if [ "${{ matrix.os }}" = "macos-latest" ]; then
+            go build -v -ldflags="-linkmode=external" ./...
+          else
+            go build -v ./...
+          fi
       - name: Test all packages
-        run: go test -v ./...
+        run: |
+          if [ "${{ matrix.os }}" = "macos-latest" ]; then
+            go test -v -ldflags="-linkmode=external" ./...
+          else
+            go test -v ./...
+          fi
 
   lint:
     strategy:
       matrix:
         go-version:
-          - 1.22.x
+          - 1.21.x
         os:
           - ubuntu-latest
     name: 'Lint ${{ matrix.dir }} (${{ matrix.os }}, Go ${{ matrix.go-version }})'
@@ -85,7 +95,7 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - 1.22.x
+          - 1.21.x
         os:
           - ubuntu-latest
     name: 'Lint CGO (${{ matrix.os}}, Go ${{ matrix.go-version }})'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - 1.21.x
+          - 1.22.x
         os:
           - macos-latest
           - ubuntu-latest
@@ -55,18 +55,13 @@ jobs:
       - name: Build all packages
         run: go build -v ./...
       - name: Test all packages
-        run: |
-          if [ "${{ matrix.os }}" = "macos-latest" ]; then
-            go test -v -ldflags="-linkmode=external" ./...
-          else
-            go test -v ./...
-          fi
+        run: go test -v ./...
 
   lint:
     strategy:
       matrix:
         go-version:
-          - 1.21.x
+          - 1.22.x
         os:
           - ubuntu-latest
     name: 'Lint ${{ matrix.dir }} (${{ matrix.os }}, Go ${{ matrix.go-version }})'
@@ -90,7 +85,7 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - 1.21.x
+          - 1.22.x
         os:
           - ubuntu-latest
     name: 'Lint CGO (${{ matrix.os}}, Go ${{ matrix.go-version }})'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -55,7 +55,12 @@ jobs:
       - name: Build all packages
         run: go build -v ./...
       - name: Test all packages
-        run: go test -v ./...
+        run: |
+          if [ "${{ matrix.os }}" = "macos-latest" ]; then
+            go test -v -ldflags="-linkmode=external" ./...
+          else
+            go test -v ./...
+          fi
 
   lint:
     strategy:

--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ This type contains six fields:
 *   `TrustedRoots *x509.CertPool`: if `nil`, uses the library's embedded
     certificate.
     Certificate chain verification is performed using trusted roots.
-*   `TcbStatusCheck bool`: if true, then `TdxQuote` will check the TCB status
-    reported by Intel PCS. If false (default), TCB status checks are skipped.
+*   `TcbStatusCheck bool`: if true (default), then `TdxQuote` will check the TCB
+    status reported by Intel PCS. If false, TCB status checks are skipped.
 
 ## `rtmr`
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ verify.TdxQuote(myAttestation, verify.Options())
 
 #### `Options` type
 
-This type contains five fields:
+This type contains seven fields:
 
 *   `GetCollateral bool`: if true, then `TdxQuote` will download the collateral
     from Intel PCS API service and check against collateral obtained.
@@ -102,11 +102,16 @@ This type contains five fields:
     The `HTTPSGetter` interface consists of a single method `Get(url string)
     (map[string][]string, []byte, error)` that should return the headers and body
     of the HTTPS response.
-*   `Now time.Time`: if `nil`, uses `time.Now()`. It is the time at which to verify
-    the validity of certificates and collaterals.
+*   `Now *TimeSet`: if `nil`, uses `defaultTimeSet()`. It is the set of times at
+    which to verify the validity of certificates and collaterals.
 *   `TrustedRoots *x509.CertPool`: if `nil`, uses the library's embedded
     certificate.
     Certificate chain verification is performed using trusted roots.
+*   `MinTcbDate time.Time`: if set, TCB levels with a release date before this
+    will be rejected. If unset (zero time), TCB date verification is skipped.
+*   `TcbTtl time.Duration`: if set, TCB levels with a release date older than
+    Now minus TcbTtl will be rejected. If unset (zero duration), TCB age verification
+    is skipped.
 
 ## `rtmr`
 

--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ This type contains six fields:
 *   `TrustedRoots *x509.CertPool`: if `nil`, uses the library's embedded
     certificate.
     Certificate chain verification is performed using trusted roots.
-*   `TcbStatusCheck bool`: if true (default), then `TdxQuote` will check the TCB
-    status reported by Intel PCS. If false, TCB status checks are skipped.
+*   `DisableTcbStatusCheck bool`: if true, then `TdxQuote` will NOT check the TCB
+    status reported by Intel PCS. Default is `false`.
 
 ## `rtmr`
 

--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ This type contains seven fields:
     Certificate chain verification is performed using trusted roots.
 *   `MinTcbDate time.Time`: if set, TCB levels with a release date before this
     will be rejected. If unset (zero time), TCB date verification is skipped.
-*   `TcbTtl time.Duration`: if set, TCB levels with a release date older than
-    Now minus TcbTtl will be rejected. If unset (zero duration), TCB age verification
+*   `TcbTTL time.Duration`: if set, TCB levels with a release date older than
+    Now minus TcbTTL will be rejected. If unset (zero duration), TCB age verification
     is skipped.
 
 ## `rtmr`

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ verify.TdxQuote(myAttestation, verify.Options())
 
 #### `Options` type
 
-This type contains seven fields:
+This type contains six fields:
 
 *   `GetCollateral bool`: if true, then `TdxQuote` will download the collateral
     from Intel PCS API service and check against collateral obtained.
@@ -107,11 +107,8 @@ This type contains seven fields:
 *   `TrustedRoots *x509.CertPool`: if `nil`, uses the library's embedded
     certificate.
     Certificate chain verification is performed using trusted roots.
-*   `MinTcbDate time.Time`: if set, TCB levels with a release date before this
-    will be rejected. If unset (zero time), TCB date verification is skipped.
-*   `TcbTTL time.Duration`: if set, TCB levels with a release date older than
-    Now minus TcbTTL will be rejected. If unset (zero duration), TCB age verification
-    is skipped.
+*   `TcbStatusCheck bool`: if true, then `TdxQuote` will check the TCB status
+    reported by Intel PCS. If false (default), TCB status checks are skipped.
 
 ## `rtmr`
 

--- a/testing/testdata/README.md
+++ b/testing/testdata/README.md
@@ -92,7 +92,7 @@ issued by Intel requires following steps:
 3. If any of the checks above fail, the identity of the enclave does not match
    Enclave Identity published by Intel.
 
-4. Determine a TCB status of the Enclave:
+4. Determine a TCB date of the Enclave:
 
   a. Retrieve a collection of TCB Levels (sorted by ISVSVNs) from tcbLevels field
      in Enclave Identity structure.
@@ -100,7 +100,7 @@ issued by Intel requires following steps:
   b. Go over the list of TCB Levels (descending order) and find the one that has
      ISVSVN that is lower or equal to the ISVSVN value from SGX Enclave Report.
 
-  c. If a TCB level is found, read its status from tcbStatus field, otherwise
+  c. If a TCB level is found, read its date from tcbDate field, otherwise
      the TCB Level is not supported.
 
 This sample API follows a structure similar to

--- a/testing/testdata/README.md
+++ b/testing/testdata/README.md
@@ -92,7 +92,7 @@ issued by Intel requires following steps:
 3. If any of the checks above fail, the identity of the enclave does not match
    Enclave Identity published by Intel.
 
-4. Determine a TCB date of the Enclave:
+4. Determine a TCB status of the Enclave:
 
   a. Retrieve a collection of TCB Levels (sorted by ISVSVNs) from tcbLevels field
      in Enclave Identity structure.
@@ -100,7 +100,7 @@ issued by Intel requires following steps:
   b. Go over the list of TCB Levels (descending order) and find the one that has
      ISVSVN that is lower or equal to the ISVSVN value from SGX Enclave Report.
 
-  c. If a TCB level is found, read its date from tcbDate field, otherwise
+  c. If a TCB level is found, read its status from tcbStatus field, otherwise
      the TCB Level is not supported.
 
 This sample API follows a structure similar to

--- a/tools/check/check.go
+++ b/tools/check/check.go
@@ -114,7 +114,7 @@ var (
 	getcollateral   = flag.String("get_collateral", "", "If true, then permitted to download necessary collaterals for additional checks.")
 	timeout         = flag.Duration("timeout", defaultTimeout, "Duration to continue to retry failed HTTP requests.")
 	maxRetryDelay   = flag.Duration("max_retry_delay", defaultMaxRetryDelay, "Maximum Duration to wait between HTTP request retries.")
-	tcbStatusCheck  = flag.Bool("tcb_status_check", false, "If true, checks the TCB status reported by Intel PCS.")
+	tcbStatusCheck  = flag.Bool("tcb_status_check", true, "If true, checks the TCB status reported by Intel PCS.")
 	testLocalGetter = flag.Bool("test_local_getter", false, "Use this flag only to test this CLI tool when network access is not available")
 
 	// Assign the values of the flags to the corresponding proto fields

--- a/tools/check/check.go
+++ b/tools/check/check.go
@@ -110,12 +110,12 @@ var (
 	minpcesvn = flag.String("minimum_pce_svn", "", "The minimum acceptable value for PCE_SVN field.")
 
 	// Optional Bool
-	checkcrl        = flag.String("check_crl", "", "Download and check the CRL for revoked certificates. -get_collateral must be true.")
-	getcollateral   = flag.String("get_collateral", "", "If true, then permitted to download necessary collaterals for additional checks.")
-	timeout         = flag.Duration("timeout", defaultTimeout, "Duration to continue to retry failed HTTP requests.")
-	maxRetryDelay   = flag.Duration("max_retry_delay", defaultMaxRetryDelay, "Maximum Duration to wait between HTTP request retries.")
-	tcbStatusCheck  = flag.Bool("tcb_status_check", true, "If true, checks the TCB status reported by Intel PCS.")
-	testLocalGetter = flag.Bool("test_local_getter", false, "Use this flag only to test this CLI tool when network access is not available")
+	checkcrl              = flag.String("check_crl", "", "Download and check the CRL for revoked certificates. -get_collateral must be true.")
+	getcollateral         = flag.String("get_collateral", "", "If true, then permitted to download necessary collaterals for additional checks.")
+	timeout               = flag.Duration("timeout", defaultTimeout, "Duration to continue to retry failed HTTP requests.")
+	maxRetryDelay         = flag.Duration("max_retry_delay", defaultMaxRetryDelay, "Maximum Duration to wait between HTTP request retries.")
+	disableTcbStatusCheck = flag.Bool("disable_tcb_status_check", false, "If true, the check will NOT verify TCB status.")
+	testLocalGetter       = flag.Bool("test_local_getter", false, "Use this flag only to test this CLI tool when network access is not available")
 
 	// Assign the values of the flags to the corresponding proto fields
 	config = &ccpb.Config{
@@ -435,7 +435,7 @@ func main() {
 	if err != nil {
 		die(err)
 	}
-	sopts.TcbStatusCheck = *tcbStatusCheck
+	sopts.DisableTcbStatusCheck = *disableTcbStatusCheck
 	logger.V(1).Info("Input parameters parsed successfully")
 
 	var getter trust.HTTPSGetter

--- a/tools/check/check.go
+++ b/tools/check/check.go
@@ -114,8 +114,7 @@ var (
 	getcollateral   = flag.String("get_collateral", "", "If true, then permitted to download necessary collaterals for additional checks.")
 	timeout         = flag.Duration("timeout", defaultTimeout, "Duration to continue to retry failed HTTP requests.")
 	maxRetryDelay   = flag.Duration("max_retry_delay", defaultMaxRetryDelay, "Maximum Duration to wait between HTTP request retries.")
-	tcbTTL          = flag.Duration("tcb_ttl", 0, "The maximum allowed age of the TCB at the time of verification.")
-	minTcbDateS     = flag.String("min_tcb_date", "", "The minimum required release date for the TCB in RFC3339 format (e.g. 2026-06-22T12:00:00Z).")
+	tcbStatusCheck  = flag.Bool("tcb_status_check", false, "If true, checks the TCB status reported by Intel PCS.")
 	testLocalGetter = flag.Bool("test_local_getter", false, "Use this flag only to test this CLI tool when network access is not available")
 
 	// Assign the values of the flags to the corresponding proto fields
@@ -436,14 +435,7 @@ func main() {
 	if err != nil {
 		die(err)
 	}
-	sopts.TcbTTL = *tcbTTL
-	if *minTcbDateS != "" {
-		minTcbDate, err := time.Parse(time.RFC3339, *minTcbDateS)
-		if err != nil {
-			dieWith(fmt.Errorf("invalid -min_tcb_date format: %v", err), exitParse)
-		}
-		sopts.MinTcbDate = minTcbDate
-	}
+	sopts.TcbStatusCheck = *tcbStatusCheck
 	logger.V(1).Info("Input parameters parsed successfully")
 
 	var getter trust.HTTPSGetter

--- a/tools/check/check.go
+++ b/tools/check/check.go
@@ -114,6 +114,8 @@ var (
 	getcollateral   = flag.String("get_collateral", "", "If true, then permitted to download necessary collaterals for additional checks.")
 	timeout         = flag.Duration("timeout", defaultTimeout, "Duration to continue to retry failed HTTP requests.")
 	maxRetryDelay   = flag.Duration("max_retry_delay", defaultMaxRetryDelay, "Maximum Duration to wait between HTTP request retries.")
+	tcbTTL          = flag.Duration("tcb_ttl", 0, "The maximum allowed age of the TCB at the time of verification.")
+	minTcbDateS     = flag.String("min_tcb_date", "", "The minimum required release date for the TCB in RFC3339 format (e.g. 2026-06-22T12:00:00Z).")
 	testLocalGetter = flag.Bool("test_local_getter", false, "Use this flag only to test this CLI tool when network access is not available")
 
 	// Assign the values of the flags to the corresponding proto fields
@@ -433,6 +435,14 @@ func main() {
 	sopts, err := verify.RootOfTrustToOptions(config.RootOfTrust)
 	if err != nil {
 		die(err)
+	}
+	sopts.TcbTTL = *tcbTTL
+	if *minTcbDateS != "" {
+		minTcbDate, err := time.Parse(time.RFC3339, *minTcbDateS)
+		if err != nil {
+			dieWith(fmt.Errorf("invalid -min_tcb_date format: %v", err), exitParse)
+		}
+		sopts.MinTcbDate = minTcbDate
 	}
 	logger.V(1).Info("Input parameters parsed successfully")
 

--- a/tools/check/check_test.go
+++ b/tools/check/check_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"runtime"
 	"strconv"
 	"testing"
 
@@ -51,7 +52,13 @@ type testCase struct {
 var check string
 
 func TestMain(m *testing.M) {
-	if output, err := exec.Command("go", "build", "-buildvcs=false", ".").CombinedOutput(); err != nil {
+	args := []string{"build", "-buildvcs=false"}
+	if runtime.GOOS == "darwin" {
+		args = append(args, "-ldflags=-linkmode=external")
+	}
+	args = append(args, ".")
+
+	if output, err := exec.Command("go", args...).CombinedOutput(); err != nil {
 		die(fmt.Errorf("could not build check tool: %v, %s", err, output))
 	}
 	check = "./check"

--- a/verify/verify.go
+++ b/verify/verify.go
@@ -32,10 +32,10 @@ import (
 	"math/big"
 	"net/url"
 	"os"
-	"reflect"
 	"strings"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-tdx-guest/abi"
 	"github.com/google/go-tdx-guest/pcs"
 	ccpb "github.com/google/go-tdx-guest/proto/checkconfig"
@@ -147,6 +147,10 @@ var (
 	ErrTdxTcbStatus = errors.New("unable to find latest status of TDX TCB, it is now OutOfDate")
 	// ErrEnclaveTcbStatus error returned when Enclave TCB status is out of date
 	ErrEnclaveTcbStatus = errors.New("unable to find latest status of Enclave TCB, it is now OutOfDate")
+	// ErrTdxTcbTooOld error returned when TDX TCB release date is before the minimum required date
+	ErrTdxTcbTooOld = errors.New("TDX TCB release date is before the minimum required date")
+	// ErrEnclaveTcbTooOld error returned when Enclave TCB release date is before the minimum required date
+	ErrEnclaveTcbTooOld = errors.New("Enclave TCB release date is before the minimum required date")
 	// ErrCertNil error returned when certificate is not provided
 	ErrCertNil = errors.New("certificate is nil")
 	// ErrParentCertNil error returned when parent certificate is not provided
@@ -603,10 +607,10 @@ func verifyCollateral(options *Options) error {
 	if collateral.EnclaveIdentityBody == nil {
 		return ErrMissingEnclaveIdentityBody
 	}
-	if reflect.DeepEqual(collateral.TdxTcbInfo, pcs.TdxTcbInfo{}) {
+	if cmp.Equal(collateral.TdxTcbInfo, pcs.TdxTcbInfo{}) {
 		return ErrTcbInfoNil
 	}
-	if reflect.DeepEqual(collateral.QeIdentity, pcs.QeIdentity{}) {
+	if cmp.Equal(collateral.QeIdentity, pcs.QeIdentity{}) {
 		return ErrQeIdentityNil
 	}
 
@@ -1033,7 +1037,7 @@ func checkQeTcb(tcbLevels []pcs.TcbLevel, isvsvn uint32, minTcbDate time.Time) e
 	}
 
 	if tcbDate.Before(minTcbDate) {
-		return ErrEnclaveTcbStatus
+		return ErrEnclaveTcbTooOld
 	}
 
 	return nil
@@ -1082,7 +1086,7 @@ func isConfigurationNeeded(status pcs.TcbComponentStatus) bool {
 	return status == pcs.TcbComponentStatusConfigurationNeeded || status == pcs.TcbComponentStatusConfigurationAndSWHardeningNeeded || status == pcs.TcbComponentStatusOutOfDateConfigurationNeeded || status == pcs.TcbComponentStatusRelaunchAdvisedConfigurationNeeded
 }
 
-func determineRelaunchAdvised(teeTcbSvn2 []byte, matchedTcbLevel pcs.TcbLevel, tdxModuleTcbLevel pcs.TcbLevel, tcbInfo pcs.TcbInfo, minTcbDate time.Time) error {
+func determineRelaunchAdvised(teeTcbSvn2 []byte, matchedTcbLevel, tdxModuleTcbLevel pcs.TcbLevel, tcbInfo pcs.TcbInfo, minTcbDate time.Time) error {
 	var relaunchRequired bool
 	if minTcbDate.IsZero() {
 		tdxModuleStatus := tdxModuleTcbLevel.TcbStatus
@@ -1140,7 +1144,7 @@ func checkTcbInfoTcb(tcbInfo pcs.TcbInfo, tdQuoteBody any, pckCertExtensions *pc
 		if found.TcbStatus == pcs.TcbComponentStatusOutOfDate {
 			return ErrTdxTcbStatus
 		}
-		if !reflect.DeepEqual(tdxModuleFound, pcs.TcbLevel{}) {
+		if !cmp.Equal(tdxModuleFound, pcs.TcbLevel{}) {
 			if err := determineRelaunchAdvised(teeTcbSvn2, found, tdxModuleFound, tcbInfo, minTcbDate); err != nil {
 				return err
 			}
@@ -1156,11 +1160,11 @@ func checkTcbInfoTcb(tcbInfo pcs.TcbInfo, tdQuoteBody any, pckCertExtensions *pc
 		return fmt.Errorf("failed to parse TDX TCB date %q: %v", found.TcbDate, err)
 	}
 	if platformTcbDate.Before(minTcbDate) {
-		return ErrTdxTcbStatus
+		return ErrTdxTcbTooOld
 	}
 
 	// Relaunch is advisable if matching TCB level is newer than TDX Module level.
-	if !reflect.DeepEqual(tdxModuleFound, pcs.TcbLevel{}) {
+	if !cmp.Equal(tdxModuleFound, pcs.TcbLevel{}) {
 		if err := determineRelaunchAdvised(teeTcbSvn2, found, tdxModuleFound, tcbInfo, minTcbDate); err != nil {
 			return err
 		}

--- a/verify/verify.go
+++ b/verify/verify.go
@@ -198,9 +198,9 @@ type Options struct {
 	// If set, TCB levels with a release date before this will be rejected.
 	// If unset (zero time), TCB date verification is skipped.
 	MinTcbDate time.Time
-	// TcbTtl is the maximum allowed age of the TCB at the time of verification.
-	// If set, TCB levels with a release date older than Now minus TcbTtl will be rejected.
-	TcbTtl time.Duration
+	// TcbTTL is the maximum allowed age of the TCB at the time of verification.
+	// If set, TCB levels with a release date older than Now minus TcbTTL will be rejected.
+	TcbTTL time.Duration
 
 	chain             *PCKCertificateChain
 	collateral        *Collateral
@@ -1291,16 +1291,16 @@ func verifyQuote(quote any, options *Options) error {
 	}
 
 	tcbMinDate := options.MinTcbDate
-	if options.TcbTtl > 0 {
-		ttlMinDate := options.Now.TcbInfo.Add(-options.TcbTtl)
+	if options.TcbTTL > 0 {
+		ttlMinDate := options.Now.TcbInfo.Add(-options.TcbTTL)
 		if tcbMinDate.IsZero() || ttlMinDate.After(tcbMinDate) {
 			tcbMinDate = ttlMinDate
 		}
 	}
 
 	qeMinDate := options.MinTcbDate
-	if options.TcbTtl > 0 {
-		ttlMinDate := options.Now.QeIdentity.Add(-options.TcbTtl)
+	if options.TcbTTL > 0 {
+		ttlMinDate := options.Now.QeIdentity.Add(-options.TcbTTL)
 		if qeMinDate.IsZero() || ttlMinDate.After(qeMinDate) {
 			qeMinDate = ttlMinDate
 		}

--- a/verify/verify.go
+++ b/verify/verify.go
@@ -194,6 +194,13 @@ type Options struct {
 	// TrustedRoots specifies the root CertPool to trust when verifying PCK certificate chain.
 	// If nil, embedded certificate will be used
 	TrustedRoots *x509.CertPool
+	// MinTcbDate is the minimum allowed release date for the TCB.
+	// If set, TCB levels with a release date before this will be rejected.
+	// If unset (zero time), TCB date verification is skipped.
+	MinTcbDate time.Time
+	// TcbTtl is the maximum allowed age of the TCB at the time of verification.
+	// If set, TCB levels with a release date older than Now minus TcbTtl will be rejected.
+	TcbTtl time.Duration
 
 	chain             *PCKCertificateChain
 	collateral        *Collateral
@@ -230,10 +237,12 @@ func DefaultOptions() *Options {
 type tdQuoteBodyOptions struct {
 	tcbInfo           pcs.TcbInfo
 	pckCertExtensions *pcs.PckExtensions
+	minTcbDate        time.Time
 }
 
 type qeReportOptions struct {
 	qeIdentity *pcs.EnclaveIdentity
+	minTcbDate time.Time
 }
 
 // PCKCertificateChain contains certificate chains
@@ -1002,18 +1011,29 @@ func readQeTcbStatus(tcbLevels []pcs.TcbLevel, isvsvn uint32) (pcs.TcbLevel, err
 	return pcs.TcbLevel{}, fmt.Errorf("no matching QE TCB level found")
 }
 
-func checkQeTcbStatus(tcbLevels []pcs.TcbLevel, isvsvn uint32) error {
+func checkQeTcb(tcbLevels []pcs.TcbLevel, isvsvn uint32, minTcbDate time.Time) error {
 	found, err := readQeTcbStatus(tcbLevels, isvsvn)
 	if err != nil {
 		return err
 	}
 
-	if found.TcbStatus == pcs.TcbComponentStatusOutOfDate {
-		return ErrEnclaveTcbStatus
+	if minTcbDate.IsZero() {
+		if found.TcbStatus == pcs.TcbComponentStatusOutOfDate {
+			return ErrEnclaveTcbStatus
+		}
+		if found.TcbStatus != pcs.TcbComponentStatusUpToDate {
+			return fmt.Errorf("QE TCB Status is not %q, found %q", pcs.TcbComponentStatusUpToDate, found.TcbStatus)
+		}
+		return nil
 	}
 
-	if found.TcbStatus != pcs.TcbComponentStatusUpToDate {
-		return fmt.Errorf("QE TCB Status is not %q, found %q", pcs.TcbComponentStatusUpToDate, found.TcbStatus)
+	tcbDate, err := time.Parse(time.RFC3339, found.TcbDate)
+	if err != nil {
+		return fmt.Errorf("failed to parse QE TCB date %q: %v", found.TcbDate, err)
+	}
+
+	if tcbDate.Before(minTcbDate) {
+		return ErrEnclaveTcbStatus
 	}
 
 	return nil
@@ -1062,16 +1082,27 @@ func isConfigurationNeeded(status pcs.TcbComponentStatus) bool {
 	return status == pcs.TcbComponentStatusConfigurationNeeded || status == pcs.TcbComponentStatusConfigurationAndSWHardeningNeeded || status == pcs.TcbComponentStatusOutOfDateConfigurationNeeded || status == pcs.TcbComponentStatusRelaunchAdvisedConfigurationNeeded
 }
 
-func determineRelaunchAdvised(teeTcbSvn2 []byte, matchedTcbLevelStatus pcs.TcbComponentStatus, tdxModuleTcbStatus pcs.TcbComponentStatus, tcbInfo pcs.TcbInfo) error {
-	// if Quote is with TDX1.5 module and if tdxModuleTcbStatus is OutOfDate, relaunch might be required
-	if teeTcbSvn2 != nil && (tdxModuleTcbStatus == pcs.TcbComponentStatusOutOfDate || tdxModuleTcbStatus == pcs.TcbComponentStatusOutOfDateConfigurationNeeded) {
+func determineRelaunchAdvised(teeTcbSvn2 []byte, matchedTcbLevel pcs.TcbLevel, tdxModuleTcbLevel pcs.TcbLevel, tcbInfo pcs.TcbInfo, minTcbDate time.Time) error {
+	var relaunchRequired bool
+	if minTcbDate.IsZero() {
+		tdxModuleStatus := tdxModuleTcbLevel.TcbStatus
+		relaunchRequired = teeTcbSvn2 != nil && (tdxModuleStatus == pcs.TcbComponentStatusOutOfDate || tdxModuleStatus == pcs.TcbComponentStatusOutOfDateConfigurationNeeded)
+	} else {
+		tdxModuleTcbDate, err := time.Parse(time.RFC3339, tdxModuleTcbLevel.TcbDate)
+		if err != nil {
+			return fmt.Errorf("failed to parse TDX Module TCB date %q: %v", tdxModuleTcbLevel.TcbDate, err)
+		}
+		relaunchRequired = teeTcbSvn2 != nil && tdxModuleTcbDate.Before(minTcbDate)
+	}
+
+	if relaunchRequired {
 		latestTcbLevel := tcbInfo.TcbLevels[0]
 		// default TDX module identity
 		if teeTcbSvn2[1] == 0 {
 			// If the host's current SVNs (at index 0 and 2) are greater than or equal to the latest requirements, it means the host has been patched.
 			//  Even if the TD was launched on an old version, the host is now capable of running a secure version.
 			if teeTcbSvn2[0] >= latestTcbLevel.Tcb.TdxTcbcomponents[0].Svn && teeTcbSvn2[2] >= latestTcbLevel.Tcb.TdxTcbcomponents[2].Svn {
-				if isConfigurationNeeded(matchedTcbLevelStatus) || isConfigurationNeeded(tdxModuleTcbStatus) {
+				if isConfigurationNeeded(matchedTcbLevel.TcbStatus) || isConfigurationNeeded(tdxModuleTcbLevel.TcbStatus) {
 					return ErrTcbTdRelaunchAdvicedConfiguratonNeeded
 				}
 
@@ -1085,7 +1116,7 @@ func determineRelaunchAdvised(teeTcbSvn2 []byte, matchedTcbLevelStatus pcs.TcbCo
 				return err
 			}
 			if uint32(teeTcbSvn2[0]) >= tdxModuleIdentity2.Tcb.Isvsvn && teeTcbSvn2[2] >= latestTcbLevel.Tcb.TdxTcbcomponents[2].Svn {
-				if isConfigurationNeeded(tdxModuleTcbStatus) || isConfigurationNeeded(matchedTcbLevelStatus) {
+				if isConfigurationNeeded(tdxModuleTcbLevel.TcbStatus) || isConfigurationNeeded(matchedTcbLevel.TcbStatus) {
 					return ErrTcbTdRelaunchAdvicedConfiguratonNeeded
 				}
 				return ErrTcbTdRelaunchAdvised
@@ -1095,7 +1126,7 @@ func determineRelaunchAdvised(teeTcbSvn2 []byte, matchedTcbLevelStatus pcs.TcbCo
 	return nil
 }
 
-func checkTcbInfoTcbStatus(tcbInfo pcs.TcbInfo, tdQuoteBody any, pckCertExtensions *pcs.PckExtensions) error {
+func checkTcbInfoTcb(tcbInfo pcs.TcbInfo, tdQuoteBody any, pckCertExtensions *pcs.PckExtensions, minTcbDate time.Time) error {
 	_, teeTcbSvn2, err := getTeeTcbSvn(tdQuoteBody)
 	if err != nil {
 		return err
@@ -1105,23 +1136,34 @@ func checkTcbInfoTcbStatus(tcbInfo pcs.TcbInfo, tdQuoteBody any, pckCertExtensio
 		return err
 	}
 
-	if found.TcbStatus == pcs.TcbComponentStatusOutOfDate {
-		return ErrTdxTcbStatus
-	}
-	var tdxModuleTcbStatus pcs.TcbComponentStatus
-	if reflect.DeepEqual(tdxModuleFound, pcs.TcbLevel{}) {
-		tdxModuleTcbStatus = pcs.TcbComponentStatusUpToDate
-	} else {
-		// when teeTcbSvn[1] > 0, tdxModuleFound is the matching TDX Module TCB Level.
-		tdxModuleTcbStatus = tdxModuleFound.TcbStatus
+	if minTcbDate.IsZero() {
+		if found.TcbStatus == pcs.TcbComponentStatusOutOfDate {
+			return ErrTdxTcbStatus
+		}
+		if !reflect.DeepEqual(tdxModuleFound, pcs.TcbLevel{}) {
+			if err := determineRelaunchAdvised(teeTcbSvn2, found, tdxModuleFound, tcbInfo, minTcbDate); err != nil {
+				return err
+			}
+		}
+		if found.TcbStatus != pcs.TcbComponentStatusUpToDate {
+			return fmt.Errorf("TDX TCB Status is not %q, found %q", pcs.TcbComponentStatusUpToDate, found.TcbStatus)
+		}
+		return nil
 	}
 
-	// Relaunch is advisable if matching TCB level status is UptoDate and TDX Module level status is OutOfDate.
-	if err := determineRelaunchAdvised(teeTcbSvn2, found.TcbStatus, tdxModuleTcbStatus, tcbInfo); err != nil {
-		return err
+	platformTcbDate, err := time.Parse(time.RFC3339, found.TcbDate)
+	if err != nil {
+		return fmt.Errorf("failed to parse TDX TCB date %q: %v", found.TcbDate, err)
 	}
-	if found.TcbStatus != pcs.TcbComponentStatusUpToDate {
-		return fmt.Errorf("TDX TCB Status is not %q, found %q", pcs.TcbComponentStatusUpToDate, found.TcbStatus)
+	if platformTcbDate.Before(minTcbDate) {
+		return ErrTdxTcbStatus
+	}
+
+	// Relaunch is advisable if matching TCB level is newer than TDX Module level.
+	if !reflect.DeepEqual(tdxModuleFound, pcs.TcbLevel{}) {
+		if err := determineRelaunchAdvised(teeTcbSvn2, found, tdxModuleFound, tcbInfo, minTcbDate); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -1169,7 +1211,7 @@ func verifyTdQuoteBody(tdQuoteBody any, tdQuoteBodyOptions *tdQuoteBodyOptions) 
 		return fmt.Errorf("AttributesMask value(%q) is not equal to TdxModule.Attributes field in Intel PCS's reported TDX TCB info(%q)", hex.EncodeToString(attributesMask), hex.EncodeToString(tdQuoteBodyOptions.tcbInfo.TdxModule.Attributes.Bytes))
 	}
 
-	if err := checkTcbInfoTcbStatus(tdQuoteBodyOptions.tcbInfo, tdQuoteBody, tdQuoteBodyOptions.pckCertExtensions); err != nil {
+	if err := checkTcbInfoTcb(tdQuoteBodyOptions.tcbInfo, tdQuoteBody, tdQuoteBodyOptions.pckCertExtensions, tdQuoteBodyOptions.minTcbDate); err != nil {
 		return fmt.Errorf("TDX TCB info reported by Intel PCS failed TCB status check: %v", err)
 	}
 	return nil
@@ -1212,7 +1254,7 @@ func verifyQeReport(qeReport *pb.EnclaveReport, qeReportOptions *qeReportOptions
 		return fmt.Errorf("ISV PRODID value(%v) in QE Report is not equal to ISV PRODID value(%v) in Intel PCS's reported QE Identity", qeReport.GetIsvProdId(), qeReportOptions.qeIdentity.IsvProdID)
 	}
 
-	if err := checkQeTcbStatus(qeReportOptions.qeIdentity.TcbLevels, qeReport.GetIsvSvn()); err != nil {
+	if err := checkQeTcb(qeReportOptions.qeIdentity.TcbLevels, qeReport.GetIsvSvn(), qeReportOptions.minTcbDate); err != nil {
 		return fmt.Errorf("QE Identity reported by Intel PCS failed TCB status check: %v", err)
 	}
 	return nil
@@ -1246,6 +1288,22 @@ func verifyQuote(quote any, options *Options) error {
 	signedData, err := getSignedData(quote)
 	if err != nil {
 		return err
+	}
+
+	tcbMinDate := options.MinTcbDate
+	if options.TcbTtl > 0 {
+		ttlMinDate := options.Now.TcbInfo.Add(-options.TcbTtl)
+		if tcbMinDate.IsZero() || ttlMinDate.After(tcbMinDate) {
+			tcbMinDate = ttlMinDate
+		}
+	}
+
+	qeMinDate := options.MinTcbDate
+	if options.TcbTtl > 0 {
+		ttlMinDate := options.Now.QeIdentity.Add(-options.TcbTtl)
+		if qeMinDate.IsZero() || ttlMinDate.After(qeMinDate) {
+			qeMinDate = ttlMinDate
+		}
 	}
 
 	chain := options.chain
@@ -1303,6 +1361,7 @@ func verifyQuote(quote any, options *Options) error {
 		if err := verifyQeReport(qeReportCertificationData.GetQeReport(),
 			&qeReportOptions{
 				qeIdentity: &collateral.QeIdentity.EnclaveIdentity,
+				minTcbDate: qeMinDate,
 			}); err != nil {
 			return err
 		}
@@ -1316,12 +1375,14 @@ func verifyQuote(quote any, options *Options) error {
 				&tdQuoteBodyOptions{
 					tcbInfo:           collateral.TdxTcbInfo.TcbInfo,
 					pckCertExtensions: pckCertExtensions,
+					minTcbDate:        tcbMinDate,
 				})
 		case *pb.QuoteV5:
 			err = verifyTdQuoteBody(q.GetTdQuoteBodyDescriptor().GetTdQuoteBodyV5(),
 				&tdQuoteBodyOptions{
 					tcbInfo:           collateral.TdxTcbInfo.TcbInfo,
 					pckCertExtensions: pckCertExtensions,
+					minTcbDate:        tcbMinDate,
 				})
 		default:
 			return fmt.Errorf("unsupported quote type: %T", quote)

--- a/verify/verify.go
+++ b/verify/verify.go
@@ -194,8 +194,8 @@ type Options struct {
 	// TrustedRoots specifies the root CertPool to trust when verifying PCK certificate chain.
 	// If nil, embedded certificate will be used
 	TrustedRoots *x509.CertPool
-	// TcbStatusCheck set to true if the verifier should check TCB status reported by Intel PCS.
-	TcbStatusCheck bool
+	// DisableTcbStatusCheck set to true if the verifier should NOT check TCB status reported by Intel PCS.
+	DisableTcbStatusCheck bool
 
 	chain             *PCKCertificateChain
 	collateral        *Collateral
@@ -224,21 +224,21 @@ func defaultTimeSet() *TimeSet {
 // DefaultOptions returns a useful default verification option setting
 func DefaultOptions() *Options {
 	return &Options{
-		Getter:         trust.DefaultHTTPSGetter(),
-		Now:            defaultTimeSet(),
-		TcbStatusCheck: true,
+		Getter:                trust.DefaultHTTPSGetter(),
+		Now:                   defaultTimeSet(),
+		DisableTcbStatusCheck: false,
 	}
 }
 
 type tdQuoteBodyOptions struct {
-	tcbInfo           pcs.TcbInfo
-	pckCertExtensions *pcs.PckExtensions
-	tcbStatusCheck    bool
+	tcbInfo               pcs.TcbInfo
+	pckCertExtensions     *pcs.PckExtensions
+	disableTcbStatusCheck bool
 }
 
 type qeReportOptions struct {
-	qeIdentity     *pcs.EnclaveIdentity
-	tcbStatusCheck bool
+	qeIdentity            *pcs.EnclaveIdentity
+	disableTcbStatusCheck bool
 }
 
 // PCKCertificateChain contains certificate chains
@@ -1174,7 +1174,7 @@ func verifyTdQuoteBody(tdQuoteBody any, tdQuoteBodyOptions *tdQuoteBodyOptions) 
 		return fmt.Errorf("AttributesMask value(%q) is not equal to TdxModule.Attributes field in Intel PCS's reported TDX TCB info(%q)", hex.EncodeToString(attributesMask), hex.EncodeToString(tdQuoteBodyOptions.tcbInfo.TdxModule.Attributes.Bytes))
 	}
 
-	if tdQuoteBodyOptions.tcbStatusCheck {
+	if !tdQuoteBodyOptions.disableTcbStatusCheck {
 		if err := checkTcbInfoTcbStatus(tdQuoteBodyOptions.tcbInfo, tdQuoteBody, tdQuoteBodyOptions.pckCertExtensions); err != nil {
 			return fmt.Errorf("TDX TCB info reported by Intel PCS failed TCB status check: %v", err)
 		}
@@ -1219,7 +1219,7 @@ func verifyQeReport(qeReport *pb.EnclaveReport, qeReportOptions *qeReportOptions
 		return fmt.Errorf("ISV PRODID value(%v) in QE Report is not equal to ISV PRODID value(%v) in Intel PCS's reported QE Identity", qeReport.GetIsvProdId(), qeReportOptions.qeIdentity.IsvProdID)
 	}
 
-	if qeReportOptions.tcbStatusCheck {
+	if !qeReportOptions.disableTcbStatusCheck {
 		if err := checkQeTcbStatus(qeReportOptions.qeIdentity.TcbLevels, qeReport.GetIsvSvn()); err != nil {
 			return fmt.Errorf("QE Identity reported by Intel PCS failed TCB status check: %v", err)
 		}
@@ -1311,8 +1311,8 @@ func verifyQuote(quote any, options *Options) error {
 		logger.V(1).Info("Verifying QE Report using QE Identity API response")
 		if err := verifyQeReport(qeReportCertificationData.GetQeReport(),
 			&qeReportOptions{
-				qeIdentity:     &collateral.QeIdentity.EnclaveIdentity,
-				tcbStatusCheck: options.TcbStatusCheck,
+				qeIdentity:            &collateral.QeIdentity.EnclaveIdentity,
+				disableTcbStatusCheck: options.DisableTcbStatusCheck,
 			}); err != nil {
 			return err
 		}
@@ -1324,16 +1324,16 @@ func verifyQuote(quote any, options *Options) error {
 		case *pb.QuoteV4:
 			err = verifyTdQuoteBody(q.GetTdQuoteBody(),
 				&tdQuoteBodyOptions{
-					tcbInfo:           collateral.TdxTcbInfo.TcbInfo,
-					pckCertExtensions: pckCertExtensions,
-					tcbStatusCheck:    options.TcbStatusCheck,
+					tcbInfo:               collateral.TdxTcbInfo.TcbInfo,
+					pckCertExtensions:     pckCertExtensions,
+					disableTcbStatusCheck: options.DisableTcbStatusCheck,
 				})
 		case *pb.QuoteV5:
 			err = verifyTdQuoteBody(q.GetTdQuoteBodyDescriptor().GetTdQuoteBodyV5(),
 				&tdQuoteBodyOptions{
-					tcbInfo:           collateral.TdxTcbInfo.TcbInfo,
-					pckCertExtensions: pckCertExtensions,
-					tcbStatusCheck:    options.TcbStatusCheck,
+					tcbInfo:               collateral.TdxTcbInfo.TcbInfo,
+					pckCertExtensions:     pckCertExtensions,
+					disableTcbStatusCheck: options.DisableTcbStatusCheck,
 				})
 		default:
 			return fmt.Errorf("unsupported quote type: %T", quote)

--- a/verify/verify.go
+++ b/verify/verify.go
@@ -224,8 +224,9 @@ func defaultTimeSet() *TimeSet {
 // DefaultOptions returns a useful default verification option setting
 func DefaultOptions() *Options {
 	return &Options{
-		Getter: trust.DefaultHTTPSGetter(),
-		Now:    defaultTimeSet(),
+		Getter:         trust.DefaultHTTPSGetter(),
+		Now:            defaultTimeSet(),
+		TcbStatusCheck: true,
 	}
 }
 

--- a/verify/verify.go
+++ b/verify/verify.go
@@ -150,7 +150,7 @@ var (
 	// ErrTdxTcbTooOld error returned when TDX TCB release date is before the minimum required date
 	ErrTdxTcbTooOld = errors.New("TDX TCB release date is before the minimum required date")
 	// ErrEnclaveTcbTooOld error returned when Enclave TCB release date is before the minimum required date
-	ErrEnclaveTcbTooOld = errors.New("Enclave TCB release date is before the minimum required date")
+	ErrEnclaveTcbTooOld = errors.New("enclave TCB release date is before the minimum required date")
 	// ErrCertNil error returned when certificate is not provided
 	ErrCertNil = errors.New("certificate is nil")
 	// ErrParentCertNil error returned when parent certificate is not provided

--- a/verify/verify.go
+++ b/verify/verify.go
@@ -147,10 +147,6 @@ var (
 	ErrTdxTcbStatus = errors.New("unable to find latest status of TDX TCB, it is now OutOfDate")
 	// ErrEnclaveTcbStatus error returned when Enclave TCB status is out of date
 	ErrEnclaveTcbStatus = errors.New("unable to find latest status of Enclave TCB, it is now OutOfDate")
-	// ErrTdxTcbTooOld error returned when TDX TCB release date is before the minimum required date
-	ErrTdxTcbTooOld = errors.New("TDX TCB release date is before the minimum required date")
-	// ErrEnclaveTcbTooOld error returned when Enclave TCB release date is before the minimum required date
-	ErrEnclaveTcbTooOld = errors.New("enclave TCB release date is before the minimum required date")
 	// ErrCertNil error returned when certificate is not provided
 	ErrCertNil = errors.New("certificate is nil")
 	// ErrParentCertNil error returned when parent certificate is not provided
@@ -198,13 +194,8 @@ type Options struct {
 	// TrustedRoots specifies the root CertPool to trust when verifying PCK certificate chain.
 	// If nil, embedded certificate will be used
 	TrustedRoots *x509.CertPool
-	// MinTcbDate is the minimum allowed release date for the TCB.
-	// If set, TCB levels with a release date before this will be rejected.
-	// If unset (zero time), TCB date verification is skipped.
-	MinTcbDate time.Time
-	// TcbTTL is the maximum allowed age of the TCB at the time of verification.
-	// If set, TCB levels with a release date older than Now minus TcbTTL will be rejected.
-	TcbTTL time.Duration
+	// TcbStatusCheck set to true if the verifier should check TCB status reported by Intel PCS.
+	TcbStatusCheck bool
 
 	chain             *PCKCertificateChain
 	collateral        *Collateral
@@ -241,12 +232,12 @@ func DefaultOptions() *Options {
 type tdQuoteBodyOptions struct {
 	tcbInfo           pcs.TcbInfo
 	pckCertExtensions *pcs.PckExtensions
-	minTcbDate        time.Time
+	tcbStatusCheck    bool
 }
 
 type qeReportOptions struct {
-	qeIdentity *pcs.EnclaveIdentity
-	minTcbDate time.Time
+	qeIdentity     *pcs.EnclaveIdentity
+	tcbStatusCheck bool
 }
 
 // PCKCertificateChain contains certificate chains
@@ -1015,29 +1006,18 @@ func readQeTcbStatus(tcbLevels []pcs.TcbLevel, isvsvn uint32) (pcs.TcbLevel, err
 	return pcs.TcbLevel{}, fmt.Errorf("no matching QE TCB level found")
 }
 
-func checkQeTcb(tcbLevels []pcs.TcbLevel, isvsvn uint32, minTcbDate time.Time) error {
+func checkQeTcbStatus(tcbLevels []pcs.TcbLevel, isvsvn uint32) error {
 	found, err := readQeTcbStatus(tcbLevels, isvsvn)
 	if err != nil {
 		return err
 	}
 
-	if minTcbDate.IsZero() {
-		if found.TcbStatus == pcs.TcbComponentStatusOutOfDate {
-			return ErrEnclaveTcbStatus
-		}
-		if found.TcbStatus != pcs.TcbComponentStatusUpToDate {
-			return fmt.Errorf("QE TCB Status is not %q, found %q", pcs.TcbComponentStatusUpToDate, found.TcbStatus)
-		}
-		return nil
+	if found.TcbStatus == pcs.TcbComponentStatusOutOfDate {
+		return ErrEnclaveTcbStatus
 	}
 
-	tcbDate, err := time.Parse(time.RFC3339, found.TcbDate)
-	if err != nil {
-		return fmt.Errorf("failed to parse QE TCB date %q: %v", found.TcbDate, err)
-	}
-
-	if tcbDate.Before(minTcbDate) {
-		return ErrEnclaveTcbTooOld
+	if found.TcbStatus != pcs.TcbComponentStatusUpToDate {
+		return fmt.Errorf("QE TCB Status is not %q, found %q", pcs.TcbComponentStatusUpToDate, found.TcbStatus)
 	}
 
 	return nil
@@ -1086,27 +1066,16 @@ func isConfigurationNeeded(status pcs.TcbComponentStatus) bool {
 	return status == pcs.TcbComponentStatusConfigurationNeeded || status == pcs.TcbComponentStatusConfigurationAndSWHardeningNeeded || status == pcs.TcbComponentStatusOutOfDateConfigurationNeeded || status == pcs.TcbComponentStatusRelaunchAdvisedConfigurationNeeded
 }
 
-func determineRelaunchAdvised(teeTcbSvn2 []byte, matchedTcbLevel, tdxModuleTcbLevel pcs.TcbLevel, tcbInfo pcs.TcbInfo, minTcbDate time.Time) error {
-	var relaunchRequired bool
-	if minTcbDate.IsZero() {
-		tdxModuleStatus := tdxModuleTcbLevel.TcbStatus
-		relaunchRequired = teeTcbSvn2 != nil && (tdxModuleStatus == pcs.TcbComponentStatusOutOfDate || tdxModuleStatus == pcs.TcbComponentStatusOutOfDateConfigurationNeeded)
-	} else {
-		tdxModuleTcbDate, err := time.Parse(time.RFC3339, tdxModuleTcbLevel.TcbDate)
-		if err != nil {
-			return fmt.Errorf("failed to parse TDX Module TCB date %q: %v", tdxModuleTcbLevel.TcbDate, err)
-		}
-		relaunchRequired = teeTcbSvn2 != nil && tdxModuleTcbDate.Before(minTcbDate)
-	}
-
-	if relaunchRequired {
+func determineRelaunchAdvised(teeTcbSvn2 []byte, matchedTcbLevelStatus pcs.TcbComponentStatus, tdxModuleTcbStatus pcs.TcbComponentStatus, tcbInfo pcs.TcbInfo) error {
+	// if Quote is with TDX1.5 module and if tdxModuleTcbStatus is OutOfDate, relaunch might be required
+	if teeTcbSvn2 != nil && (tdxModuleTcbStatus == pcs.TcbComponentStatusOutOfDate || tdxModuleTcbStatus == pcs.TcbComponentStatusOutOfDateConfigurationNeeded) {
 		latestTcbLevel := tcbInfo.TcbLevels[0]
 		// default TDX module identity
 		if teeTcbSvn2[1] == 0 {
 			// If the host's current SVNs (at index 0 and 2) are greater than or equal to the latest requirements, it means the host has been patched.
 			//  Even if the TD was launched on an old version, the host is now capable of running a secure version.
 			if teeTcbSvn2[0] >= latestTcbLevel.Tcb.TdxTcbcomponents[0].Svn && teeTcbSvn2[2] >= latestTcbLevel.Tcb.TdxTcbcomponents[2].Svn {
-				if isConfigurationNeeded(matchedTcbLevel.TcbStatus) || isConfigurationNeeded(tdxModuleTcbLevel.TcbStatus) {
+				if isConfigurationNeeded(matchedTcbLevelStatus) || isConfigurationNeeded(tdxModuleTcbStatus) {
 					return ErrTcbTdRelaunchAdvicedConfiguratonNeeded
 				}
 
@@ -1120,7 +1089,7 @@ func determineRelaunchAdvised(teeTcbSvn2 []byte, matchedTcbLevel, tdxModuleTcbLe
 				return err
 			}
 			if uint32(teeTcbSvn2[0]) >= tdxModuleIdentity2.Tcb.Isvsvn && teeTcbSvn2[2] >= latestTcbLevel.Tcb.TdxTcbcomponents[2].Svn {
-				if isConfigurationNeeded(tdxModuleTcbLevel.TcbStatus) || isConfigurationNeeded(matchedTcbLevel.TcbStatus) {
+				if isConfigurationNeeded(tdxModuleTcbStatus) || isConfigurationNeeded(matchedTcbLevelStatus) {
 					return ErrTcbTdRelaunchAdvicedConfiguratonNeeded
 				}
 				return ErrTcbTdRelaunchAdvised
@@ -1130,7 +1099,7 @@ func determineRelaunchAdvised(teeTcbSvn2 []byte, matchedTcbLevel, tdxModuleTcbLe
 	return nil
 }
 
-func checkTcbInfoTcb(tcbInfo pcs.TcbInfo, tdQuoteBody any, pckCertExtensions *pcs.PckExtensions, minTcbDate time.Time) error {
+func checkTcbInfoTcbStatus(tcbInfo pcs.TcbInfo, tdQuoteBody any, pckCertExtensions *pcs.PckExtensions) error {
 	_, teeTcbSvn2, err := getTeeTcbSvn(tdQuoteBody)
 	if err != nil {
 		return err
@@ -1140,34 +1109,23 @@ func checkTcbInfoTcb(tcbInfo pcs.TcbInfo, tdQuoteBody any, pckCertExtensions *pc
 		return err
 	}
 
-	if minTcbDate.IsZero() {
-		if found.TcbStatus == pcs.TcbComponentStatusOutOfDate {
-			return ErrTdxTcbStatus
-		}
-		if !cmp.Equal(tdxModuleFound, pcs.TcbLevel{}) {
-			if err := determineRelaunchAdvised(teeTcbSvn2, found, tdxModuleFound, tcbInfo, minTcbDate); err != nil {
-				return err
-			}
-		}
-		if found.TcbStatus != pcs.TcbComponentStatusUpToDate {
-			return fmt.Errorf("TDX TCB Status is not %q, found %q", pcs.TcbComponentStatusUpToDate, found.TcbStatus)
-		}
-		return nil
+	if found.TcbStatus == pcs.TcbComponentStatusOutOfDate {
+		return ErrTdxTcbStatus
+	}
+	var tdxModuleTcbStatus pcs.TcbComponentStatus
+	if cmp.Equal(tdxModuleFound, pcs.TcbLevel{}) {
+		tdxModuleTcbStatus = pcs.TcbComponentStatusUpToDate
+	} else {
+		// when teeTcbSvn[1] > 0, tdxModuleFound is the matching TDX Module TCB Level.
+		tdxModuleTcbStatus = tdxModuleFound.TcbStatus
 	}
 
-	platformTcbDate, err := time.Parse(time.RFC3339, found.TcbDate)
-	if err != nil {
-		return fmt.Errorf("failed to parse TDX TCB date %q: %v", found.TcbDate, err)
+	// Relaunch is advisable if matching TCB level status is UptoDate and TDX Module level status is OutOfDate.
+	if err := determineRelaunchAdvised(teeTcbSvn2, found.TcbStatus, tdxModuleTcbStatus, tcbInfo); err != nil {
+		return err
 	}
-	if platformTcbDate.Before(minTcbDate) {
-		return ErrTdxTcbTooOld
-	}
-
-	// Relaunch is advisable if matching TCB level is newer than TDX Module level.
-	if !cmp.Equal(tdxModuleFound, pcs.TcbLevel{}) {
-		if err := determineRelaunchAdvised(teeTcbSvn2, found, tdxModuleFound, tcbInfo, minTcbDate); err != nil {
-			return err
-		}
+	if found.TcbStatus != pcs.TcbComponentStatusUpToDate {
+		return fmt.Errorf("TDX TCB Status is not %q, found %q", pcs.TcbComponentStatusUpToDate, found.TcbStatus)
 	}
 
 	return nil
@@ -1215,8 +1173,10 @@ func verifyTdQuoteBody(tdQuoteBody any, tdQuoteBodyOptions *tdQuoteBodyOptions) 
 		return fmt.Errorf("AttributesMask value(%q) is not equal to TdxModule.Attributes field in Intel PCS's reported TDX TCB info(%q)", hex.EncodeToString(attributesMask), hex.EncodeToString(tdQuoteBodyOptions.tcbInfo.TdxModule.Attributes.Bytes))
 	}
 
-	if err := checkTcbInfoTcb(tdQuoteBodyOptions.tcbInfo, tdQuoteBody, tdQuoteBodyOptions.pckCertExtensions, tdQuoteBodyOptions.minTcbDate); err != nil {
-		return fmt.Errorf("TDX TCB info reported by Intel PCS failed TCB status check: %v", err)
+	if tdQuoteBodyOptions.tcbStatusCheck {
+		if err := checkTcbInfoTcbStatus(tdQuoteBodyOptions.tcbInfo, tdQuoteBody, tdQuoteBodyOptions.pckCertExtensions); err != nil {
+			return fmt.Errorf("TDX TCB info reported by Intel PCS failed TCB status check: %v", err)
+		}
 	}
 	return nil
 }
@@ -1258,8 +1218,10 @@ func verifyQeReport(qeReport *pb.EnclaveReport, qeReportOptions *qeReportOptions
 		return fmt.Errorf("ISV PRODID value(%v) in QE Report is not equal to ISV PRODID value(%v) in Intel PCS's reported QE Identity", qeReport.GetIsvProdId(), qeReportOptions.qeIdentity.IsvProdID)
 	}
 
-	if err := checkQeTcb(qeReportOptions.qeIdentity.TcbLevels, qeReport.GetIsvSvn(), qeReportOptions.minTcbDate); err != nil {
-		return fmt.Errorf("QE Identity reported by Intel PCS failed TCB status check: %v", err)
+	if qeReportOptions.tcbStatusCheck {
+		if err := checkQeTcbStatus(qeReportOptions.qeIdentity.TcbLevels, qeReport.GetIsvSvn()); err != nil {
+			return fmt.Errorf("QE Identity reported by Intel PCS failed TCB status check: %v", err)
+		}
 	}
 	return nil
 }
@@ -1292,22 +1254,6 @@ func verifyQuote(quote any, options *Options) error {
 	signedData, err := getSignedData(quote)
 	if err != nil {
 		return err
-	}
-
-	tcbMinDate := options.MinTcbDate
-	if options.TcbTTL > 0 {
-		ttlMinDate := options.Now.TcbInfo.Add(-options.TcbTTL)
-		if tcbMinDate.IsZero() || ttlMinDate.After(tcbMinDate) {
-			tcbMinDate = ttlMinDate
-		}
-	}
-
-	qeMinDate := options.MinTcbDate
-	if options.TcbTTL > 0 {
-		ttlMinDate := options.Now.QeIdentity.Add(-options.TcbTTL)
-		if qeMinDate.IsZero() || ttlMinDate.After(qeMinDate) {
-			qeMinDate = ttlMinDate
-		}
 	}
 
 	chain := options.chain
@@ -1364,8 +1310,8 @@ func verifyQuote(quote any, options *Options) error {
 		logger.V(1).Info("Verifying QE Report using QE Identity API response")
 		if err := verifyQeReport(qeReportCertificationData.GetQeReport(),
 			&qeReportOptions{
-				qeIdentity: &collateral.QeIdentity.EnclaveIdentity,
-				minTcbDate: qeMinDate,
+				qeIdentity:     &collateral.QeIdentity.EnclaveIdentity,
+				tcbStatusCheck: options.TcbStatusCheck,
 			}); err != nil {
 			return err
 		}
@@ -1379,14 +1325,14 @@ func verifyQuote(quote any, options *Options) error {
 				&tdQuoteBodyOptions{
 					tcbInfo:           collateral.TdxTcbInfo.TcbInfo,
 					pckCertExtensions: pckCertExtensions,
-					minTcbDate:        tcbMinDate,
+					tcbStatusCheck:    options.TcbStatusCheck,
 				})
 		case *pb.QuoteV5:
 			err = verifyTdQuoteBody(q.GetTdQuoteBodyDescriptor().GetTdQuoteBodyV5(),
 				&tdQuoteBodyOptions{
 					tcbInfo:           collateral.TdxTcbInfo.TcbInfo,
 					pckCertExtensions: pckCertExtensions,
-					minTcbDate:        tcbMinDate,
+					tcbStatusCheck:    options.TcbStatusCheck,
 				})
 		default:
 			return fmt.Errorf("unsupported quote type: %T", quote)

--- a/verify/verify_test.go
+++ b/verify/verify_test.go
@@ -945,7 +945,7 @@ func TestValidateCRL(t *testing.T) {
 
 func TestNegativeRawQuoteVerifyWithCollateral(t *testing.T) {
 	getter := testcases.TestGetter
-	options := &Options{CheckRevocations: true, GetCollateral: true, Getter: getter, Now: testTimeSet(currentTime), TcbStatusCheck: true}
+	options := &Options{CheckRevocations: true, GetCollateral: true, Getter: getter, Now: testTimeSet(currentTime), DisableTcbStatusCheck: false}
 	wantErr := "TDX TCB info reported by Intel PCS failed TCB status check: no matching TCB level found"
 	// Due to updated SVN values in the sample response, it will result in TCB status failure,
 	// when compared to the TD Quote Body's TeeTcbSvn value.
@@ -1232,7 +1232,7 @@ var rawTdxQuoteFuncs = map[string]func([]byte, *Options) error{
 	},
 }
 
-func TestTcbStatusCheckOption(t *testing.T) {
+func TestDisableTcbStatusCheckOption(t *testing.T) {
 	getter := testcases.TestGetter
 
 	fmspcBytes := []byte{80, 128, 111, 0, 0, 0}
@@ -1283,26 +1283,26 @@ func TestTcbStatusCheckOption(t *testing.T) {
 	tcbInfo.TcbLevels[0].TcbStatus = "OutOfDate"
 
 	optsFalse := Options{
-		GetCollateral:     true,
-		Now:               defaultTimeSet(),
-		chain:             chain,
-		collateral:        collateral,
-		pckCertExtensions: ext,
-		TcbStatusCheck:    false,
+		GetCollateral:         true,
+		Now:                   defaultTimeSet(),
+		chain:                 chain,
+		collateral:            collateral,
+		pckCertExtensions:     ext,
+		DisableTcbStatusCheck: true,
 	}
 	if err := verifyQuote(quote, &optsFalse); err != nil {
-		t.Errorf("verifyQuote() with TcbStatusCheck=false got error %v, want nil", err)
+		t.Errorf("verifyQuote() with DisableTcbStatusCheck=true got error %v, want nil", err)
 	}
 
 	optsTrue := Options{
-		GetCollateral:     true,
-		Now:               defaultTimeSet(),
-		chain:             chain,
-		collateral:        collateral,
-		pckCertExtensions: ext,
-		TcbStatusCheck:    true,
+		GetCollateral:         true,
+		Now:                   defaultTimeSet(),
+		chain:                 chain,
+		collateral:            collateral,
+		pckCertExtensions:     ext,
+		DisableTcbStatusCheck: false,
 	}
 	if err := verifyQuote(quote, &optsTrue); err == nil || !strings.Contains(err.Error(), ErrTdxTcbStatus.Error()) {
-		t.Errorf("verifyQuote() with TcbStatusCheck=true got %v, want error containing %v", err, ErrTdxTcbStatus)
+		t.Errorf("verifyQuote() with DisableTcbStatusCheck=false got %v, want error containing %v", err, ErrTdxTcbStatus)
 	}
 }

--- a/verify/verify_test.go
+++ b/verify/verify_test.go
@@ -1299,7 +1299,7 @@ var rawTdxQuoteFuncs = map[string]func([]byte, *Options) error{
 	},
 }
 
-func TestTcbTtlValidation(t *testing.T) {
+func TestTcbTTLValidation(t *testing.T) {
 	getter := testcases.TestGetter
 
 	fmspcBytes := []byte{80, 128, 111, 0, 0, 0}
@@ -1363,22 +1363,22 @@ func TestTcbTtlValidation(t *testing.T) {
 	}
 
 	// TCB age (10 days) < TTL (15 days) => success
-	options.TcbTtl = 15 * 24 * time.Hour
+	options.TcbTTL = 15 * 24 * time.Hour
 	if err := verifyQuote(quote, options); err != nil {
-		t.Errorf("verifyQuote failed with TcbTtl of 15 days: %v", err)
+		t.Errorf("verifyQuote failed with TcbTTL of 15 days: %v", err)
 	}
 
 	// TCB age (10 days) > TTL (5 days) => fail
-	options.TcbTtl = 5 * 24 * time.Hour
+	options.TcbTTL = 5 * 24 * time.Hour
 	wantErr := fmt.Errorf("TDX TCB info reported by Intel PCS failed TCB status check: %v", ErrTdxTcbStatus)
 	if err := verifyQuote(quote, options); err == nil || err.Error() != wantErr.Error() {
-		t.Errorf("verifyQuote with TcbTtl of 5 days returned error %v, want %v", err, wantErr)
+		t.Errorf("verifyQuote with TcbTTL of 5 days returned error %v, want %v", err, wantErr)
 	}
 
 	// TCB age (10 days) < TTL (15 days) AND MinTcbDate (5 days ago) => fail
-	options.TcbTtl = 15 * 24 * time.Hour
+	options.TcbTTL = 15 * 24 * time.Hour
 	options.MinTcbDate = now.Add(-5 * 24 * time.Hour)
 	if err := verifyQuote(quote, options); err == nil || err.Error() != wantErr.Error() {
-		t.Errorf("verifyQuote with MinTcbDate (5 days ago) and TcbTtl (15 days) returned error %v, want %v", err, wantErr)
+		t.Errorf("verifyQuote with MinTcbDate (5 days ago) and TcbTTL (15 days) returned error %v, want %v", err, wantErr)
 	}
 }

--- a/verify/verify_test.go
+++ b/verify/verify_test.go
@@ -19,7 +19,6 @@ import (
 	"crypto/x509"
 	"encoding/hex"
 	"errors"
-	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -876,7 +875,7 @@ func TestNegativeTcbInfoTcbDateV4(t *testing.T) {
 	tcbInfo.TcbLevels[0].Tcb.Pcesvn = 0
 	minTcbDate := time.Now()
 	tcbInfo.TcbLevels[0].TcbDate = minTcbDate.Add(-24 * time.Hour).Format(time.RFC3339)
-	if gotErr, wantErr := checkTcbInfoTcb(tcbInfo, quote.GetTdQuoteBody(), ext, minTcbDate), ErrTdxTcbStatus; gotErr == nil || !errors.Is(gotErr, wantErr) {
+	if gotErr, wantErr := checkTcbInfoTcb(tcbInfo, quote.GetTdQuoteBody(), ext, minTcbDate), ErrTdxTcbTooOld; gotErr == nil || !errors.Is(gotErr, wantErr) {
 		t.Errorf("TCB date expired: checkTcbInfoTcb() = %v. Want error %v", gotErr, wantErr)
 	}
 }
@@ -909,7 +908,7 @@ func TestNegativeCheckQeDateV4(t *testing.T) {
 	qeIdentity.TcbLevels[0].Tcb.Isvsvn = 0
 	minTcbDate := time.Now()
 	qeIdentity.TcbLevels[0].TcbDate = minTcbDate.Add(-24 * time.Hour).Format(time.RFC3339)
-	if gotErr, wantErr := checkQeTcb(qeIdentity.TcbLevels, qeReport.GetIsvSvn(), minTcbDate), ErrEnclaveTcbStatus; gotErr == nil || !errors.Is(gotErr, wantErr) {
+	if gotErr, wantErr := checkQeTcb(qeIdentity.TcbLevels, qeReport.GetIsvSvn(), minTcbDate), ErrEnclaveTcbTooOld; gotErr == nil || !errors.Is(gotErr, wantErr) {
 		t.Errorf("TCB date expired: checkQeTcb() = %v. Want error %v", gotErr, wantErr)
 	}
 }
@@ -1351,34 +1350,71 @@ func TestTcbTTLValidation(t *testing.T) {
 	tcbInfo.TcbLevels[0].TcbDate = now.Add(-10 * 24 * time.Hour).Format(time.RFC3339)   // outside TTL
 	qeIdentity.TcbLevels[0].TcbDate = now.Add(-1 * 24 * time.Hour).Format(time.RFC3339) // inside TTL
 
-	options := &Options{
-		GetCollateral: true,
-		Now: &TimeSet{
-			TcbInfo:    now,
-			QeIdentity: now,
+	testcases := []struct {
+		name    string
+		options Options
+		wantErr error
+	}{
+		{
+			name: "TCB age (10 days) < TTL (15 days) => success",
+			options: Options{
+				GetCollateral: true,
+				Now: &TimeSet{
+					TcbInfo:    now,
+					QeIdentity: now,
+				},
+				chain:             chain,
+				collateral:        collateral,
+				pckCertExtensions: ext,
+				TcbTTL:            15 * 24 * time.Hour,
+			},
+			wantErr: nil,
 		},
-		chain:             chain,
-		collateral:        collateral,
-		pckCertExtensions: ext,
+		{
+			name: "TCB age (10 days) > TTL (5 days) => fail",
+			options: Options{
+				GetCollateral: true,
+				Now: &TimeSet{
+					TcbInfo:    now,
+					QeIdentity: now,
+				},
+				chain:             chain,
+				collateral:        collateral,
+				pckCertExtensions: ext,
+				TcbTTL:            5 * 24 * time.Hour,
+			},
+			wantErr: ErrTdxTcbTooOld,
+		},
+		{
+			name: "TCB age (10 days) < TTL (15 days) AND MinTcbDate (5 days ago) => fail",
+			options: Options{
+				GetCollateral: true,
+				Now: &TimeSet{
+					TcbInfo:    now,
+					QeIdentity: now,
+				},
+				chain:             chain,
+				collateral:        collateral,
+				pckCertExtensions: ext,
+				TcbTTL:            15 * 24 * time.Hour,
+				MinTcbDate:        now.Add(-5 * 24 * time.Hour),
+			},
+			wantErr: ErrTdxTcbTooOld,
+		},
 	}
 
-	// TCB age (10 days) < TTL (15 days) => success
-	options.TcbTTL = 15 * 24 * time.Hour
-	if err := verifyQuote(quote, options); err != nil {
-		t.Errorf("verifyQuote failed with TcbTTL of 15 days: %v", err)
-	}
-
-	// TCB age (10 days) > TTL (5 days) => fail
-	options.TcbTTL = 5 * 24 * time.Hour
-	wantErr := fmt.Errorf("TDX TCB info reported by Intel PCS failed TCB status check: %v", ErrTdxTcbStatus)
-	if err := verifyQuote(quote, options); err == nil || err.Error() != wantErr.Error() {
-		t.Errorf("verifyQuote with TcbTTL of 5 days returned error %v, want %v", err, wantErr)
-	}
-
-	// TCB age (10 days) < TTL (15 days) AND MinTcbDate (5 days ago) => fail
-	options.TcbTTL = 15 * 24 * time.Hour
-	options.MinTcbDate = now.Add(-5 * 24 * time.Hour)
-	if err := verifyQuote(quote, options); err == nil || err.Error() != wantErr.Error() {
-		t.Errorf("verifyQuote with MinTcbDate (5 days ago) and TcbTTL (15 days) returned error %v, want %v", err, wantErr)
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := verifyQuote(quote, &tc.options)
+			if err != nil {
+				if tc.wantErr == nil {
+					t.Errorf("verifyQuote failed: %v", err)
+				} else if !strings.Contains(err.Error(), tc.wantErr.Error()) {
+					t.Errorf("verifyQuote error mismatch:\n got: %v\nwant: %v", err, tc.wantErr)
+				}
+			} else if tc.wantErr != nil {
+				t.Errorf("verifyQuote got nil, want: %v", tc.wantErr)
+			}
+		})
 	}
 }

--- a/verify/verify_test.go
+++ b/verify/verify_test.go
@@ -19,6 +19,7 @@ import (
 	"crypto/x509"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -827,7 +828,7 @@ func TestNegativeVerifyUsingQeIdentityV4(t *testing.T) {
 	}
 }
 
-func TestNegativeTcbInfoTcbStatusV4(t *testing.T) {
+func TestNegativeTcbInfoTcbDateV4(t *testing.T) {
 	getter := testcases.TestGetter
 
 	fmspcBytes := []byte{80, 128, 111, 0, 0, 0}
@@ -857,29 +858,30 @@ func TestNegativeTcbInfoTcbStatusV4(t *testing.T) {
 
 	setTcbSvnValues(10, 0, &tcbInfo.TcbLevels[0].Tcb.TdxTcbcomponents, &tcbInfo.TcbLevels[0].Tcb.SgxTcbcomponents)
 	wantErr := "no matching TCB level found"
-	if err := checkTcbInfoTcbStatus(tcbInfo, quote.GetTdQuoteBody(), ext); err == nil || err.Error() != wantErr {
-		t.Errorf("SgxTcbComponents values greater: checkTcbInfoTcbStatus() = %v. Want error %v", err, wantErr)
+	if err := checkTcbInfoTcb(tcbInfo, quote.GetTdQuoteBody(), ext, time.Time{}); err == nil || err.Error() != wantErr {
+		t.Errorf("SgxTcbComponents values greater: checkTcbInfoTcb() = %v. Want error %v", err, wantErr)
 	}
 
 	setTcbSvnValues(0, 10, &tcbInfo.TcbLevels[0].Tcb.TdxTcbcomponents, &tcbInfo.TcbLevels[0].Tcb.SgxTcbcomponents)
-	if err := checkTcbInfoTcbStatus(tcbInfo, quote.GetTdQuoteBody(), ext); err == nil || err.Error() != wantErr {
-		t.Errorf("TdxTcbComponents values greater: checkTcbInfoTcbStatus() = %v. Want error %v", err, wantErr)
+	if err := checkTcbInfoTcb(tcbInfo, quote.GetTdQuoteBody(), ext, time.Time{}); err == nil || err.Error() != wantErr {
+		t.Errorf("TdxTcbComponents values greater: checkTcbInfoTcb() = %v. Want error %v", err, wantErr)
 	}
 
 	tcbInfo.TcbLevels[0].Tcb.Pcesvn = 20
 	setTcbSvnValues(0, 0, &tcbInfo.TcbLevels[0].Tcb.TdxTcbcomponents, &tcbInfo.TcbLevels[0].Tcb.SgxTcbcomponents)
-	if err := checkTcbInfoTcbStatus(tcbInfo, quote.GetTdQuoteBody(), ext); err == nil || err.Error() != wantErr {
-		t.Errorf("PCESvn value greater: checkTcbInfoTcbStatus() = %v. Want error %v", err, wantErr)
+	if err := checkTcbInfoTcb(tcbInfo, quote.GetTdQuoteBody(), ext, time.Time{}); err == nil || err.Error() != wantErr {
+		t.Errorf("PCESvn value greater: checkTcbInfoTcb() = %v. Want error %v", err, wantErr)
 	}
 
 	tcbInfo.TcbLevels[0].Tcb.Pcesvn = 0
-	tcbInfo.TcbLevels[0].TcbStatus = "OutOfDate"
-	if gotErr, wantErr := checkTcbInfoTcbStatus(tcbInfo, quote.GetTdQuoteBody(), ext), ErrTdxTcbStatus; gotErr == nil || !errors.Is(gotErr, wantErr) {
-		t.Errorf("TCB status expired: checkTcbInfoTcbStatus() = %v. Want error %v", err, wantErr)
+	minTcbDate := time.Now()
+	tcbInfo.TcbLevels[0].TcbDate = minTcbDate.Add(-24 * time.Hour).Format(time.RFC3339)
+	if gotErr, wantErr := checkTcbInfoTcb(tcbInfo, quote.GetTdQuoteBody(), ext, minTcbDate), ErrTdxTcbStatus; gotErr == nil || !errors.Is(gotErr, wantErr) {
+		t.Errorf("TCB date expired: checkTcbInfoTcb() = %v. Want error %v", gotErr, wantErr)
 	}
 }
 
-func TestNegativeCheckQeStatusV4(t *testing.T) {
+func TestNegativeCheckQeDateV4(t *testing.T) {
 	getter := testcases.TestGetter
 
 	collateral := &Collateral{}
@@ -900,14 +902,15 @@ func TestNegativeCheckQeStatusV4(t *testing.T) {
 
 	qeIdentity.TcbLevels[0].Tcb.Isvsvn = 10
 	wantErr := "no matching QE TCB level found"
-	if err := checkQeTcbStatus(qeIdentity.TcbLevels, qeReport.GetIsvSvn()); err == nil || err.Error() != wantErr {
-		t.Errorf("No matching TCB level: verifyUsingQeIdentity() = %v. Want error %v", err, wantErr)
+	if err := checkQeTcb(qeIdentity.TcbLevels, qeReport.GetIsvSvn(), time.Time{}); err == nil || err.Error() != wantErr {
+		t.Errorf("No matching TCB level: checkQeTcb() = %v. Want error %v", err, wantErr)
 	}
 
 	qeIdentity.TcbLevels[0].Tcb.Isvsvn = 0
-	qeIdentity.TcbLevels[0].TcbStatus = "OutOfDate"
-	if gotErr, wantErr := checkQeTcbStatus(qeIdentity.TcbLevels, qeReport.GetIsvSvn()), ErrEnclaveTcbStatus; gotErr == nil || !errors.Is(gotErr, wantErr) {
-		t.Errorf("TCB status expired: verifyUsingQeIdentity() = %v. Want error %v", err, wantErr)
+	minTcbDate := time.Now()
+	qeIdentity.TcbLevels[0].TcbDate = minTcbDate.Add(-24 * time.Hour).Format(time.RFC3339)
+	if gotErr, wantErr := checkQeTcb(qeIdentity.TcbLevels, qeReport.GetIsvSvn(), minTcbDate), ErrEnclaveTcbStatus; gotErr == nil || !errors.Is(gotErr, wantErr) {
+		t.Errorf("TCB date expired: checkQeTcb() = %v. Want error %v", gotErr, wantErr)
 	}
 }
 
@@ -1119,99 +1122,163 @@ func TestDetermineRelaunchAdvised(t *testing.T) {
 		},
 	}
 
+	minTcbDate := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	newDate := "2026-01-02T00:00:00Z"
+	oldDate := "2025-12-31T00:00:00Z"
+
 	tests := []struct {
-		name                  string
-		teeTcbSvn2            []byte
-		matchedTCbLevelStatus pcs.TcbComponentStatus
-		tdxModuleTcbStatus    pcs.TcbComponentStatus
-		tcbInfo               pcs.TcbInfo
-		wantErr               string
+		name              string
+		teeTcbSvn2        []byte
+		matchedTcbLevel   pcs.TcbLevel
+		tdxModuleTcbLevel pcs.TcbLevel
+		tcbInfo           pcs.TcbInfo
+		wantErr           string
 	}{
 		{
-			name:                  "Nil teeTcbSvn2",
-			teeTcbSvn2:            nil,
-			matchedTCbLevelStatus: pcs.TcbComponentStatusUpToDate,
-			tdxModuleTcbStatus:    pcs.TcbComponentStatusOutOfDate,
-			tcbInfo:               tcbInfo,
-			wantErr:               "",
+			name:       "Nil teeTcbSvn2",
+			teeTcbSvn2: nil,
+			matchedTcbLevel: pcs.TcbLevel{
+				TcbStatus: pcs.TcbComponentStatusUpToDate,
+				TcbDate:   newDate,
+			},
+			tdxModuleTcbLevel: pcs.TcbLevel{
+				TcbStatus: pcs.TcbComponentStatusOutOfDate,
+				TcbDate:   oldDate,
+			},
+			tcbInfo: tcbInfo,
+			wantErr: "",
 		},
 		{
-			name:                  "TcbComponentStatus UpToDate",
-			teeTcbSvn2:            []byte{1, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-			matchedTCbLevelStatus: pcs.TcbComponentStatusUpToDate,
-			tdxModuleTcbStatus:    pcs.TcbComponentStatusUpToDate,
-			tcbInfo:               tcbInfo,
-			wantErr:               "",
+			name:       "TcbComponentStatus UpToDate",
+			teeTcbSvn2: []byte{1, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			matchedTcbLevel: pcs.TcbLevel{
+				TcbStatus: pcs.TcbComponentStatusUpToDate,
+				TcbDate:   newDate,
+			},
+			tdxModuleTcbLevel: pcs.TcbLevel{
+				TcbStatus: pcs.TcbComponentStatusUpToDate,
+				TcbDate:   newDate,
+			},
+			tcbInfo: tcbInfo,
+			wantErr: "",
 		},
 		{
-			name:                  "teeTcbSvn2[1]=0 relaunch advised without config",
-			teeTcbSvn2:            []byte{1, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-			matchedTCbLevelStatus: pcs.TcbComponentStatusUpToDate,
-			tdxModuleTcbStatus:    pcs.TcbComponentStatusOutOfDate,
-			tcbInfo:               tcbInfo,
-			wantErr:               ErrTcbTdRelaunchAdvised.Error(),
+			name:       "teeTcbSvn2[1]=0 relaunch advised without config",
+			teeTcbSvn2: []byte{1, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			matchedTcbLevel: pcs.TcbLevel{
+				TcbStatus: pcs.TcbComponentStatusUpToDate,
+				TcbDate:   newDate,
+			},
+			tdxModuleTcbLevel: pcs.TcbLevel{
+				TcbStatus: pcs.TcbComponentStatusOutOfDate,
+				TcbDate:   oldDate,
+			},
+			tcbInfo: tcbInfo,
+			wantErr: ErrTcbTdRelaunchAdvised.Error(),
 		},
 		{
-			name:                  "teeTcbSvn2[1]=0 relaunch with config changes",
-			teeTcbSvn2:            []byte{1, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-			matchedTCbLevelStatus: pcs.TcbComponentStatusConfigurationNeeded,
-			tdxModuleTcbStatus:    pcs.TcbComponentStatusOutOfDate,
-			tcbInfo:               tcbInfo,
-			wantErr:               ErrTcbTdRelaunchAdvicedConfiguratonNeeded.Error(),
+			name:       "teeTcbSvn2[1]=0 relaunch with config changes",
+			teeTcbSvn2: []byte{1, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			matchedTcbLevel: pcs.TcbLevel{
+				TcbStatus: pcs.TcbComponentStatusConfigurationNeeded,
+				TcbDate:   newDate,
+			},
+			tdxModuleTcbLevel: pcs.TcbLevel{
+				TcbStatus: pcs.TcbComponentStatusOutOfDate,
+				TcbDate:   oldDate,
+			},
+			tcbInfo: tcbInfo,
+			wantErr: ErrTcbTdRelaunchAdvicedConfiguratonNeeded.Error(),
 		},
 		{
-			name:                  "teeTcbSvn2[1]=0 relaunch with config from tdxModule",
-			teeTcbSvn2:            []byte{1, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-			matchedTCbLevelStatus: pcs.TcbComponentStatusUpToDate,
-			tdxModuleTcbStatus:    pcs.TcbComponentStatusOutOfDateConfigurationNeeded,
-			tcbInfo:               tcbInfo,
-			wantErr:               ErrTcbTdRelaunchAdvicedConfiguratonNeeded.Error(),
+			name:       "teeTcbSvn2[1]=0 relaunch with config from tdxModule",
+			teeTcbSvn2: []byte{1, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			matchedTcbLevel: pcs.TcbLevel{
+				TcbStatus: pcs.TcbComponentStatusUpToDate,
+				TcbDate:   newDate,
+			},
+			tdxModuleTcbLevel: pcs.TcbLevel{
+				TcbStatus: pcs.TcbComponentStatusOutOfDateConfigurationNeeded,
+				TcbDate:   oldDate,
+			},
+			tcbInfo: tcbInfo,
+			wantErr: ErrTcbTdRelaunchAdvicedConfiguratonNeeded.Error(),
 		},
 		{
-			name:                  "teeTcbSvn2[1]=0 no relaunch conditions should succeed",
-			teeTcbSvn2:            []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-			matchedTCbLevelStatus: pcs.TcbComponentStatusUpToDate,
-			tdxModuleTcbStatus:    pcs.TcbComponentStatusOutOfDate,
-			tcbInfo:               tcbInfo,
-			wantErr:               "",
+			name:       "teeTcbSvn2[1]=0 no relaunch conditions should succeed",
+			teeTcbSvn2: []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			matchedTcbLevel: pcs.TcbLevel{
+				TcbStatus: pcs.TcbComponentStatusUpToDate,
+				TcbDate:   newDate,
+			},
+			tdxModuleTcbLevel: pcs.TcbLevel{
+				TcbStatus: pcs.TcbComponentStatusOutOfDate,
+				TcbDate:   oldDate,
+			},
+			tcbInfo: tcbInfo,
+			wantErr: "",
 		},
 		{
-			name:                  "teeTcbSvn2[1]!=0 relaunch advised",
-			teeTcbSvn2:            []byte{5, 1, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, // ID matching will look for TDX_01
-			matchedTCbLevelStatus: pcs.TcbComponentStatusUpToDate,
-			tdxModuleTcbStatus:    pcs.TcbComponentStatusOutOfDate,
-			tcbInfo:               tcbInfo,
-			wantErr:               ErrTcbTdRelaunchAdvised.Error(),
+			name:       "teeTcbSvn2[1]!=0 relaunch advised",
+			teeTcbSvn2: []byte{5, 1, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, // ID matching will look for TDX_01
+			matchedTcbLevel: pcs.TcbLevel{
+				TcbStatus: pcs.TcbComponentStatusUpToDate,
+				TcbDate:   newDate,
+			},
+			tdxModuleTcbLevel: pcs.TcbLevel{
+				TcbStatus: pcs.TcbComponentStatusOutOfDate,
+				TcbDate:   oldDate,
+			},
+			tcbInfo: tcbInfo,
+			wantErr: ErrTcbTdRelaunchAdvised.Error(),
 		},
 		{
-			name:                  "teeTcbSvn2[1]!=0 relaunch with config changes advised",
-			teeTcbSvn2:            []byte{5, 1, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, // ID matching will look for TDX_01
-			matchedTCbLevelStatus: pcs.TcbComponentStatusConfigurationNeeded,
-			tdxModuleTcbStatus:    pcs.TcbComponentStatusOutOfDate,
-			tcbInfo:               tcbInfo,
-			wantErr:               ErrTcbTdRelaunchAdvicedConfiguratonNeeded.Error(),
+			name:       "teeTcbSvn2[1]!=0 relaunch with config changes advised",
+			teeTcbSvn2: []byte{5, 1, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, // ID matching will look for TDX_01
+			matchedTcbLevel: pcs.TcbLevel{
+				TcbStatus: pcs.TcbComponentStatusConfigurationNeeded,
+				TcbDate:   newDate,
+			},
+			tdxModuleTcbLevel: pcs.TcbLevel{
+				TcbStatus: pcs.TcbComponentStatusOutOfDate,
+				TcbDate:   oldDate,
+			},
+			tcbInfo: tcbInfo,
+			wantErr: ErrTcbTdRelaunchAdvicedConfiguratonNeeded.Error(),
 		},
 		{
-			name:                  "teeTcbSvn2[1]!=0 module id mismatch ",
-			teeTcbSvn2:            []byte{5, 2, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, // ID matching will look for TDX_02
-			matchedTCbLevelStatus: pcs.TcbComponentStatusUpToDate,
-			tdxModuleTcbStatus:    pcs.TcbComponentStatusOutOfDate,
-			tcbInfo:               tcbInfo,
-			wantErr:               "could not find a TDX Module Identity (\"TDX_02\") matching the given TEE TDX version (\"\\x02\")",
+			name:       "teeTcbSvn2[1]!=0 module id mismatch ",
+			teeTcbSvn2: []byte{5, 2, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, // ID matching will look for TDX_02
+			matchedTcbLevel: pcs.TcbLevel{
+				TcbStatus: pcs.TcbComponentStatusUpToDate,
+				TcbDate:   newDate,
+			},
+			tdxModuleTcbLevel: pcs.TcbLevel{
+				TcbStatus: pcs.TcbComponentStatusOutOfDate,
+				TcbDate:   oldDate,
+			},
+			tcbInfo: tcbInfo,
+			wantErr: "could not find a TDX Module Identity (\"TDX_02\") matching the given TEE TDX version (\"\\x02\")",
 		},
 		{
-			name:                  "teeTcbSvn2[1]!=0 no relaunch conditions met",
-			teeTcbSvn2:            []byte{5, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, // teeTcbSvn2[2] (2) < latestTcbLevel.Tcb.TdxTcbcomponents[2].Svn (3)
-			matchedTCbLevelStatus: pcs.TcbComponentStatusUpToDate,
-			tdxModuleTcbStatus:    pcs.TcbComponentStatusOutOfDate,
-			tcbInfo:               tcbInfo,
-			wantErr:               "",
+			name:       "teeTcbSvn2[1]!=0 no relaunch conditions met",
+			teeTcbSvn2: []byte{5, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, // teeTcbSvn2[2] (2) < latestTcbLevel.Tcb.TdxTcbcomponents[2].Svn (3)
+			matchedTcbLevel: pcs.TcbLevel{
+				TcbStatus: pcs.TcbComponentStatusUpToDate,
+				TcbDate:   newDate,
+			},
+			tdxModuleTcbLevel: pcs.TcbLevel{
+				TcbStatus: pcs.TcbComponentStatusOutOfDate,
+				TcbDate:   oldDate,
+			},
+			tcbInfo: tcbInfo,
+			wantErr: "",
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			err := determineRelaunchAdvised(tc.teeTcbSvn2, tc.matchedTCbLevelStatus, tc.tdxModuleTcbStatus, tc.tcbInfo)
+			err := determineRelaunchAdvised(tc.teeTcbSvn2, tc.matchedTcbLevel, tc.tdxModuleTcbLevel, tc.tcbInfo, minTcbDate)
 			if err == nil {
 				if tc.wantErr != "" {
 					t.Errorf("determineRelaunchAdvised() = nil, want %v", tc.wantErr)
@@ -1230,4 +1297,88 @@ var rawTdxQuoteFuncs = map[string]func([]byte, *Options) error{
 	"RawTdxQuoteContext": func(quote []byte, options *Options) error {
 		return RawTdxQuoteContext(context.Background(), quote, options)
 	},
+}
+
+func TestTcbTtlValidation(t *testing.T) {
+	getter := testcases.TestGetter
+
+	fmspcBytes := []byte{80, 128, 111, 0, 0, 0}
+	fmspc := hex.EncodeToString(fmspcBytes)
+
+	collateral := &Collateral{}
+	if err := getTcbInfo(context.Background(), fmspc, getter, collateral); err != nil {
+		t.Fatal(err)
+	}
+	if err := getQeIdentity(context.Background(), getter, collateral); err != nil {
+		t.Fatal(err)
+	}
+	anyQuote, err := abi.QuoteToProto(testdata.RawQuote)
+	if err != nil {
+		t.Fatal(err)
+	}
+	quote, ok := anyQuote.(*pb.QuoteV4)
+	if !ok {
+		t.Fatal("quote is not a QuoteV4")
+	}
+	chain, err := ExtractChainFromQuote(quote)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ext, err := pcs.PckCertificateExtensions(chain.PCKCertificate)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tcbInfo := &collateral.TdxTcbInfo.TcbInfo
+	qeIdentity := &collateral.QeIdentity.EnclaveIdentity
+
+	// Align SVNs and fields so that both TCB Info and QE Identity matching succeeds
+	setTcbSvnValues(0, 0, &tcbInfo.TcbLevels[0].Tcb.TdxTcbcomponents, &tcbInfo.TcbLevels[0].Tcb.SgxTcbcomponents)
+	tcbInfo.TcbLevels[0].Tcb.Pcesvn = 0
+	qeIdentity.TcbLevels[0].Tcb.Isvsvn = 0
+
+	// Set MrSigner and SeamAttributes in collateral to match the quote
+	tcbInfo.TdxModule.Mrsigner.Bytes = quote.GetTdQuoteBody().GetMrSignerSeam()
+	seamAttributes := quote.GetTdQuoteBody().GetSeamAttributes()
+	tcbInfo.TdxModule.AttributesMask.Bytes = make([]byte, len(seamAttributes))
+	tcbInfo.TdxModule.Attributes.Bytes = make([]byte, len(seamAttributes))
+	for i := range seamAttributes {
+		tcbInfo.TdxModule.AttributesMask.Bytes[i] = 0xff
+		tcbInfo.TdxModule.Attributes.Bytes[i] = seamAttributes[i]
+	}
+
+	now := time.Date(2026, 6, 22, 12, 0, 0, 0, time.UTC)
+	tcbInfo.TcbLevels[0].TcbDate = now.Add(-10 * 24 * time.Hour).Format(time.RFC3339)   // outside TTL
+	qeIdentity.TcbLevels[0].TcbDate = now.Add(-1 * 24 * time.Hour).Format(time.RFC3339) // inside TTL
+
+	options := &Options{
+		GetCollateral: true,
+		Now: &TimeSet{
+			TcbInfo:    now,
+			QeIdentity: now,
+		},
+		chain:             chain,
+		collateral:        collateral,
+		pckCertExtensions: ext,
+	}
+
+	// TCB age (10 days) < TTL (15 days) => success
+	options.TcbTtl = 15 * 24 * time.Hour
+	if err := verifyQuote(quote, options); err != nil {
+		t.Errorf("verifyQuote failed with TcbTtl of 15 days: %v", err)
+	}
+
+	// TCB age (10 days) > TTL (5 days) => fail
+	options.TcbTtl = 5 * 24 * time.Hour
+	wantErr := fmt.Errorf("TDX TCB info reported by Intel PCS failed TCB status check: %v", ErrTdxTcbStatus)
+	if err := verifyQuote(quote, options); err == nil || err.Error() != wantErr.Error() {
+		t.Errorf("verifyQuote with TcbTtl of 5 days returned error %v, want %v", err, wantErr)
+	}
+
+	// TCB age (10 days) < TTL (15 days) AND MinTcbDate (5 days ago) => fail
+	options.TcbTtl = 15 * 24 * time.Hour
+	options.MinTcbDate = now.Add(-5 * 24 * time.Hour)
+	if err := verifyQuote(quote, options); err == nil || err.Error() != wantErr.Error() {
+		t.Errorf("verifyQuote with MinTcbDate (5 days ago) and TcbTtl (15 days) returned error %v, want %v", err, wantErr)
+	}
 }

--- a/verify/verify_test.go
+++ b/verify/verify_test.go
@@ -827,7 +827,7 @@ func TestNegativeVerifyUsingQeIdentityV4(t *testing.T) {
 	}
 }
 
-func TestNegativeTcbInfoTcbDateV4(t *testing.T) {
+func TestNegativeTcbInfoTcbStatusV4(t *testing.T) {
 	getter := testcases.TestGetter
 
 	fmspcBytes := []byte{80, 128, 111, 0, 0, 0}
@@ -857,30 +857,29 @@ func TestNegativeTcbInfoTcbDateV4(t *testing.T) {
 
 	setTcbSvnValues(10, 0, &tcbInfo.TcbLevels[0].Tcb.TdxTcbcomponents, &tcbInfo.TcbLevels[0].Tcb.SgxTcbcomponents)
 	wantErr := "no matching TCB level found"
-	if err := checkTcbInfoTcb(tcbInfo, quote.GetTdQuoteBody(), ext, time.Time{}); err == nil || err.Error() != wantErr {
-		t.Errorf("SgxTcbComponents values greater: checkTcbInfoTcb() = %v. Want error %v", err, wantErr)
+	if err := checkTcbInfoTcbStatus(tcbInfo, quote.GetTdQuoteBody(), ext); err == nil || err.Error() != wantErr {
+		t.Errorf("SgxTcbComponents values greater: checkTcbInfoTcbStatus() = %v. Want error %v", err, wantErr)
 	}
 
 	setTcbSvnValues(0, 10, &tcbInfo.TcbLevels[0].Tcb.TdxTcbcomponents, &tcbInfo.TcbLevels[0].Tcb.SgxTcbcomponents)
-	if err := checkTcbInfoTcb(tcbInfo, quote.GetTdQuoteBody(), ext, time.Time{}); err == nil || err.Error() != wantErr {
-		t.Errorf("TdxTcbComponents values greater: checkTcbInfoTcb() = %v. Want error %v", err, wantErr)
+	if err := checkTcbInfoTcbStatus(tcbInfo, quote.GetTdQuoteBody(), ext); err == nil || err.Error() != wantErr {
+		t.Errorf("TdxTcbComponents values greater: checkTcbInfoTcbStatus() = %v. Want error %v", err, wantErr)
 	}
 
 	tcbInfo.TcbLevels[0].Tcb.Pcesvn = 20
 	setTcbSvnValues(0, 0, &tcbInfo.TcbLevels[0].Tcb.TdxTcbcomponents, &tcbInfo.TcbLevels[0].Tcb.SgxTcbcomponents)
-	if err := checkTcbInfoTcb(tcbInfo, quote.GetTdQuoteBody(), ext, time.Time{}); err == nil || err.Error() != wantErr {
-		t.Errorf("PCESvn value greater: checkTcbInfoTcb() = %v. Want error %v", err, wantErr)
+	if err := checkTcbInfoTcbStatus(tcbInfo, quote.GetTdQuoteBody(), ext); err == nil || err.Error() != wantErr {
+		t.Errorf("PCESvn value greater: checkTcbInfoTcbStatus() = %v. Want error %v", err, wantErr)
 	}
 
 	tcbInfo.TcbLevels[0].Tcb.Pcesvn = 0
-	minTcbDate := time.Now()
-	tcbInfo.TcbLevels[0].TcbDate = minTcbDate.Add(-24 * time.Hour).Format(time.RFC3339)
-	if gotErr, wantErr := checkTcbInfoTcb(tcbInfo, quote.GetTdQuoteBody(), ext, minTcbDate), ErrTdxTcbTooOld; gotErr == nil || !errors.Is(gotErr, wantErr) {
-		t.Errorf("TCB date expired: checkTcbInfoTcb() = %v. Want error %v", gotErr, wantErr)
+	tcbInfo.TcbLevels[0].TcbStatus = "OutOfDate"
+	if gotErr, wantErr := checkTcbInfoTcbStatus(tcbInfo, quote.GetTdQuoteBody(), ext), ErrTdxTcbStatus; gotErr == nil || !errors.Is(gotErr, wantErr) {
+		t.Errorf("TCB status expired: checkTcbInfoTcbStatus() = %v. Want error %v", gotErr, wantErr)
 	}
 }
 
-func TestNegativeCheckQeDateV4(t *testing.T) {
+func TestNegativeCheckQeStatusV4(t *testing.T) {
 	getter := testcases.TestGetter
 
 	collateral := &Collateral{}
@@ -901,15 +900,14 @@ func TestNegativeCheckQeDateV4(t *testing.T) {
 
 	qeIdentity.TcbLevels[0].Tcb.Isvsvn = 10
 	wantErr := "no matching QE TCB level found"
-	if err := checkQeTcb(qeIdentity.TcbLevels, qeReport.GetIsvSvn(), time.Time{}); err == nil || err.Error() != wantErr {
-		t.Errorf("No matching TCB level: checkQeTcb() = %v. Want error %v", err, wantErr)
+	if err := checkQeTcbStatus(qeIdentity.TcbLevels, qeReport.GetIsvSvn()); err == nil || err.Error() != wantErr {
+		t.Errorf("No matching TCB level: checkQeTcbStatus() = %v. Want error %v", err, wantErr)
 	}
 
 	qeIdentity.TcbLevels[0].Tcb.Isvsvn = 0
-	minTcbDate := time.Now()
-	qeIdentity.TcbLevels[0].TcbDate = minTcbDate.Add(-24 * time.Hour).Format(time.RFC3339)
-	if gotErr, wantErr := checkQeTcb(qeIdentity.TcbLevels, qeReport.GetIsvSvn(), minTcbDate), ErrEnclaveTcbTooOld; gotErr == nil || !errors.Is(gotErr, wantErr) {
-		t.Errorf("TCB date expired: checkQeTcb() = %v. Want error %v", gotErr, wantErr)
+	qeIdentity.TcbLevels[0].TcbStatus = "OutOfDate"
+	if gotErr, wantErr := checkQeTcbStatus(qeIdentity.TcbLevels, qeReport.GetIsvSvn()), ErrEnclaveTcbStatus; gotErr == nil || !errors.Is(gotErr, wantErr) {
+		t.Errorf("TCB status expired: checkQeTcbStatus() = %v. Want error %v", gotErr, wantErr)
 	}
 }
 
@@ -947,7 +945,7 @@ func TestValidateCRL(t *testing.T) {
 
 func TestNegativeRawQuoteVerifyWithCollateral(t *testing.T) {
 	getter := testcases.TestGetter
-	options := &Options{CheckRevocations: true, GetCollateral: true, Getter: getter, Now: testTimeSet(currentTime)}
+	options := &Options{CheckRevocations: true, GetCollateral: true, Getter: getter, Now: testTimeSet(currentTime), TcbStatusCheck: true}
 	wantErr := "TDX TCB info reported by Intel PCS failed TCB status check: no matching TCB level found"
 	// Due to updated SVN values in the sample response, it will result in TCB status failure,
 	// when compared to the TD Quote Body's TeeTcbSvn value.
@@ -1121,163 +1119,99 @@ func TestDetermineRelaunchAdvised(t *testing.T) {
 		},
 	}
 
-	minTcbDate := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
-	newDate := "2026-01-02T00:00:00Z"
-	oldDate := "2025-12-31T00:00:00Z"
-
 	tests := []struct {
-		name              string
-		teeTcbSvn2        []byte
-		matchedTcbLevel   pcs.TcbLevel
-		tdxModuleTcbLevel pcs.TcbLevel
-		tcbInfo           pcs.TcbInfo
-		wantErr           string
+		name                  string
+		teeTcbSvn2            []byte
+		matchedTCbLevelStatus pcs.TcbComponentStatus
+		tdxModuleTcbStatus    pcs.TcbComponentStatus
+		tcbInfo               pcs.TcbInfo
+		wantErr               string
 	}{
 		{
-			name:       "Nil teeTcbSvn2",
-			teeTcbSvn2: nil,
-			matchedTcbLevel: pcs.TcbLevel{
-				TcbStatus: pcs.TcbComponentStatusUpToDate,
-				TcbDate:   newDate,
-			},
-			tdxModuleTcbLevel: pcs.TcbLevel{
-				TcbStatus: pcs.TcbComponentStatusOutOfDate,
-				TcbDate:   oldDate,
-			},
-			tcbInfo: tcbInfo,
-			wantErr: "",
+			name:                  "Nil teeTcbSvn2",
+			teeTcbSvn2:            nil,
+			matchedTCbLevelStatus: pcs.TcbComponentStatusUpToDate,
+			tdxModuleTcbStatus:    pcs.TcbComponentStatusOutOfDate,
+			tcbInfo:               tcbInfo,
+			wantErr:               "",
 		},
 		{
-			name:       "TcbComponentStatus UpToDate",
-			teeTcbSvn2: []byte{1, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-			matchedTcbLevel: pcs.TcbLevel{
-				TcbStatus: pcs.TcbComponentStatusUpToDate,
-				TcbDate:   newDate,
-			},
-			tdxModuleTcbLevel: pcs.TcbLevel{
-				TcbStatus: pcs.TcbComponentStatusUpToDate,
-				TcbDate:   newDate,
-			},
-			tcbInfo: tcbInfo,
-			wantErr: "",
+			name:                  "TcbComponentStatus UpToDate",
+			teeTcbSvn2:            []byte{1, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			matchedTCbLevelStatus: pcs.TcbComponentStatusUpToDate,
+			tdxModuleTcbStatus:    pcs.TcbComponentStatusUpToDate,
+			tcbInfo:               tcbInfo,
+			wantErr:               "",
 		},
 		{
-			name:       "teeTcbSvn2[1]=0 relaunch advised without config",
-			teeTcbSvn2: []byte{1, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-			matchedTcbLevel: pcs.TcbLevel{
-				TcbStatus: pcs.TcbComponentStatusUpToDate,
-				TcbDate:   newDate,
-			},
-			tdxModuleTcbLevel: pcs.TcbLevel{
-				TcbStatus: pcs.TcbComponentStatusOutOfDate,
-				TcbDate:   oldDate,
-			},
-			tcbInfo: tcbInfo,
-			wantErr: ErrTcbTdRelaunchAdvised.Error(),
+			name:                  "teeTcbSvn2[1]=0 relaunch advised without config",
+			teeTcbSvn2:            []byte{1, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			matchedTCbLevelStatus: pcs.TcbComponentStatusUpToDate,
+			tdxModuleTcbStatus:    pcs.TcbComponentStatusOutOfDate,
+			tcbInfo:               tcbInfo,
+			wantErr:               ErrTcbTdRelaunchAdvised.Error(),
 		},
 		{
-			name:       "teeTcbSvn2[1]=0 relaunch with config changes",
-			teeTcbSvn2: []byte{1, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-			matchedTcbLevel: pcs.TcbLevel{
-				TcbStatus: pcs.TcbComponentStatusConfigurationNeeded,
-				TcbDate:   newDate,
-			},
-			tdxModuleTcbLevel: pcs.TcbLevel{
-				TcbStatus: pcs.TcbComponentStatusOutOfDate,
-				TcbDate:   oldDate,
-			},
-			tcbInfo: tcbInfo,
-			wantErr: ErrTcbTdRelaunchAdvicedConfiguratonNeeded.Error(),
+			name:                  "teeTcbSvn2[1]=0 relaunch with config changes",
+			teeTcbSvn2:            []byte{1, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			matchedTCbLevelStatus: pcs.TcbComponentStatusConfigurationNeeded,
+			tdxModuleTcbStatus:    pcs.TcbComponentStatusOutOfDate,
+			tcbInfo:               tcbInfo,
+			wantErr:               ErrTcbTdRelaunchAdvicedConfiguratonNeeded.Error(),
 		},
 		{
-			name:       "teeTcbSvn2[1]=0 relaunch with config from tdxModule",
-			teeTcbSvn2: []byte{1, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-			matchedTcbLevel: pcs.TcbLevel{
-				TcbStatus: pcs.TcbComponentStatusUpToDate,
-				TcbDate:   newDate,
-			},
-			tdxModuleTcbLevel: pcs.TcbLevel{
-				TcbStatus: pcs.TcbComponentStatusOutOfDateConfigurationNeeded,
-				TcbDate:   oldDate,
-			},
-			tcbInfo: tcbInfo,
-			wantErr: ErrTcbTdRelaunchAdvicedConfiguratonNeeded.Error(),
+			name:                  "teeTcbSvn2[1]=0 relaunch with config from tdxModule",
+			teeTcbSvn2:            []byte{1, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			matchedTCbLevelStatus: pcs.TcbComponentStatusUpToDate,
+			tdxModuleTcbStatus:    pcs.TcbComponentStatusOutOfDateConfigurationNeeded,
+			tcbInfo:               tcbInfo,
+			wantErr:               ErrTcbTdRelaunchAdvicedConfiguratonNeeded.Error(),
 		},
 		{
-			name:       "teeTcbSvn2[1]=0 no relaunch conditions should succeed",
-			teeTcbSvn2: []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-			matchedTcbLevel: pcs.TcbLevel{
-				TcbStatus: pcs.TcbComponentStatusUpToDate,
-				TcbDate:   newDate,
-			},
-			tdxModuleTcbLevel: pcs.TcbLevel{
-				TcbStatus: pcs.TcbComponentStatusOutOfDate,
-				TcbDate:   oldDate,
-			},
-			tcbInfo: tcbInfo,
-			wantErr: "",
+			name:                  "teeTcbSvn2[1]=0 no relaunch conditions should succeed",
+			teeTcbSvn2:            []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			matchedTCbLevelStatus: pcs.TcbComponentStatusUpToDate,
+			tdxModuleTcbStatus:    pcs.TcbComponentStatusOutOfDate,
+			tcbInfo:               tcbInfo,
+			wantErr:               "",
 		},
 		{
-			name:       "teeTcbSvn2[1]!=0 relaunch advised",
-			teeTcbSvn2: []byte{5, 1, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, // ID matching will look for TDX_01
-			matchedTcbLevel: pcs.TcbLevel{
-				TcbStatus: pcs.TcbComponentStatusUpToDate,
-				TcbDate:   newDate,
-			},
-			tdxModuleTcbLevel: pcs.TcbLevel{
-				TcbStatus: pcs.TcbComponentStatusOutOfDate,
-				TcbDate:   oldDate,
-			},
-			tcbInfo: tcbInfo,
-			wantErr: ErrTcbTdRelaunchAdvised.Error(),
+			name:                  "teeTcbSvn2[1]!=0 relaunch advised",
+			teeTcbSvn2:            []byte{5, 1, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, // ID matching will look for TDX_01
+			matchedTCbLevelStatus: pcs.TcbComponentStatusUpToDate,
+			tdxModuleTcbStatus:    pcs.TcbComponentStatusOutOfDate,
+			tcbInfo:               tcbInfo,
+			wantErr:               ErrTcbTdRelaunchAdvised.Error(),
 		},
 		{
-			name:       "teeTcbSvn2[1]!=0 relaunch with config changes advised",
-			teeTcbSvn2: []byte{5, 1, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, // ID matching will look for TDX_01
-			matchedTcbLevel: pcs.TcbLevel{
-				TcbStatus: pcs.TcbComponentStatusConfigurationNeeded,
-				TcbDate:   newDate,
-			},
-			tdxModuleTcbLevel: pcs.TcbLevel{
-				TcbStatus: pcs.TcbComponentStatusOutOfDate,
-				TcbDate:   oldDate,
-			},
-			tcbInfo: tcbInfo,
-			wantErr: ErrTcbTdRelaunchAdvicedConfiguratonNeeded.Error(),
+			name:                  "teeTcbSvn2[1]!=0 relaunch with config changes advised",
+			teeTcbSvn2:            []byte{5, 1, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, // ID matching will look for TDX_01
+			matchedTCbLevelStatus: pcs.TcbComponentStatusConfigurationNeeded,
+			tdxModuleTcbStatus:    pcs.TcbComponentStatusOutOfDate,
+			tcbInfo:               tcbInfo,
+			wantErr:               ErrTcbTdRelaunchAdvicedConfiguratonNeeded.Error(),
 		},
 		{
-			name:       "teeTcbSvn2[1]!=0 module id mismatch ",
-			teeTcbSvn2: []byte{5, 2, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, // ID matching will look for TDX_02
-			matchedTcbLevel: pcs.TcbLevel{
-				TcbStatus: pcs.TcbComponentStatusUpToDate,
-				TcbDate:   newDate,
-			},
-			tdxModuleTcbLevel: pcs.TcbLevel{
-				TcbStatus: pcs.TcbComponentStatusOutOfDate,
-				TcbDate:   oldDate,
-			},
-			tcbInfo: tcbInfo,
-			wantErr: "could not find a TDX Module Identity (\"TDX_02\") matching the given TEE TDX version (\"\\x02\")",
+			name:                  "teeTcbSvn2[1]!=0 module id mismatch ",
+			teeTcbSvn2:            []byte{5, 2, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, // ID matching will look for TDX_02
+			matchedTCbLevelStatus: pcs.TcbComponentStatusUpToDate,
+			tdxModuleTcbStatus:    pcs.TcbComponentStatusOutOfDate,
+			tcbInfo:               tcbInfo,
+			wantErr:               "could not find a TDX Module Identity (\"TDX_02\") matching the given TEE TDX version (\"\\x02\")",
 		},
 		{
-			name:       "teeTcbSvn2[1]!=0 no relaunch conditions met",
-			teeTcbSvn2: []byte{5, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, // teeTcbSvn2[2] (2) < latestTcbLevel.Tcb.TdxTcbcomponents[2].Svn (3)
-			matchedTcbLevel: pcs.TcbLevel{
-				TcbStatus: pcs.TcbComponentStatusUpToDate,
-				TcbDate:   newDate,
-			},
-			tdxModuleTcbLevel: pcs.TcbLevel{
-				TcbStatus: pcs.TcbComponentStatusOutOfDate,
-				TcbDate:   oldDate,
-			},
-			tcbInfo: tcbInfo,
-			wantErr: "",
+			name:                  "teeTcbSvn2[1]!=0 no relaunch conditions met",
+			teeTcbSvn2:            []byte{5, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, // teeTcbSvn2[2] (2) < latestTcbLevel.Tcb.TdxTcbcomponents[2].Svn (3)
+			matchedTCbLevelStatus: pcs.TcbComponentStatusUpToDate,
+			tdxModuleTcbStatus:    pcs.TcbComponentStatusOutOfDate,
+			tcbInfo:               tcbInfo,
+			wantErr:               "",
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			err := determineRelaunchAdvised(tc.teeTcbSvn2, tc.matchedTcbLevel, tc.tdxModuleTcbLevel, tc.tcbInfo, minTcbDate)
+			err := determineRelaunchAdvised(tc.teeTcbSvn2, tc.matchedTCbLevelStatus, tc.tdxModuleTcbStatus, tc.tcbInfo)
 			if err == nil {
 				if tc.wantErr != "" {
 					t.Errorf("determineRelaunchAdvised() = nil, want %v", tc.wantErr)
@@ -1298,7 +1232,7 @@ var rawTdxQuoteFuncs = map[string]func([]byte, *Options) error{
 	},
 }
 
-func TestTcbTTLValidation(t *testing.T) {
+func TestTcbStatusCheckOption(t *testing.T) {
 	getter := testcases.TestGetter
 
 	fmspcBytes := []byte{80, 128, 111, 0, 0, 0}
@@ -1346,75 +1280,30 @@ func TestTcbTTLValidation(t *testing.T) {
 		tcbInfo.TdxModule.Attributes.Bytes[i] = seamAttributes[i]
 	}
 
-	now := time.Date(2026, 6, 22, 12, 0, 0, 0, time.UTC)
-	tcbInfo.TcbLevels[0].TcbDate = now.Add(-10 * 24 * time.Hour).Format(time.RFC3339)   // outside TTL
-	qeIdentity.TcbLevels[0].TcbDate = now.Add(-1 * 24 * time.Hour).Format(time.RFC3339) // inside TTL
+	tcbInfo.TcbLevels[0].TcbStatus = "OutOfDate"
 
-	testcases := []struct {
-		name    string
-		options Options
-		wantErr error
-	}{
-		{
-			name: "TCB age (10 days) < TTL (15 days) => success",
-			options: Options{
-				GetCollateral: true,
-				Now: &TimeSet{
-					TcbInfo:    now,
-					QeIdentity: now,
-				},
-				chain:             chain,
-				collateral:        collateral,
-				pckCertExtensions: ext,
-				TcbTTL:            15 * 24 * time.Hour,
-			},
-			wantErr: nil,
-		},
-		{
-			name: "TCB age (10 days) > TTL (5 days) => fail",
-			options: Options{
-				GetCollateral: true,
-				Now: &TimeSet{
-					TcbInfo:    now,
-					QeIdentity: now,
-				},
-				chain:             chain,
-				collateral:        collateral,
-				pckCertExtensions: ext,
-				TcbTTL:            5 * 24 * time.Hour,
-			},
-			wantErr: ErrTdxTcbTooOld,
-		},
-		{
-			name: "TCB age (10 days) < TTL (15 days) AND MinTcbDate (5 days ago) => fail",
-			options: Options{
-				GetCollateral: true,
-				Now: &TimeSet{
-					TcbInfo:    now,
-					QeIdentity: now,
-				},
-				chain:             chain,
-				collateral:        collateral,
-				pckCertExtensions: ext,
-				TcbTTL:            15 * 24 * time.Hour,
-				MinTcbDate:        now.Add(-5 * 24 * time.Hour),
-			},
-			wantErr: ErrTdxTcbTooOld,
-		},
+	optsFalse := Options{
+		GetCollateral:     true,
+		Now:               defaultTimeSet(),
+		chain:             chain,
+		collateral:        collateral,
+		pckCertExtensions: ext,
+		TcbStatusCheck:    false,
+	}
+	if err := verifyQuote(quote, &optsFalse); err != nil {
+		t.Errorf("verifyQuote() with TcbStatusCheck=false got error %v, want nil", err)
 	}
 
-	for _, tc := range testcases {
-		t.Run(tc.name, func(t *testing.T) {
-			err := verifyQuote(quote, &tc.options)
-			if err != nil {
-				if tc.wantErr == nil {
-					t.Errorf("verifyQuote failed: %v", err)
-				} else if !strings.Contains(err.Error(), tc.wantErr.Error()) {
-					t.Errorf("verifyQuote error mismatch:\n got: %v\nwant: %v", err, tc.wantErr)
-				}
-			} else if tc.wantErr != nil {
-				t.Errorf("verifyQuote got nil, want: %v", tc.wantErr)
-			}
-		})
+	optsTrue := Options{
+		GetCollateral:     true,
+		Now:               defaultTimeSet(),
+		chain:             chain,
+		collateral:        collateral,
+		pckCertExtensions: ext,
+		TcbStatusCheck:    true,
+	}
+	if err := verifyQuote(quote, &optsTrue); err == nil || !strings.Contains(err.Error(), ErrTdxTcbStatus.Error()) {
+		t.Errorf("verifyQuote() with TcbStatusCheck=true got %v, want error containing %v", err, ErrTdxTcbStatus)
 	}
 }
+

--- a/verify/verify_test.go
+++ b/verify/verify_test.go
@@ -1306,4 +1306,3 @@ func TestTcbStatusCheckOption(t *testing.T) {
 		t.Errorf("verifyQuote() with TcbStatusCheck=true got %v, want error containing %v", err, ErrTdxTcbStatus)
 	}
 }
-


### PR DESCRIPTION
- Adds option to make checking of tdxTcbStatus optional to allow for custom tdxTcbDate based checks instead as specified in https://docs.trustauthority.intel.com/main/articles/articles/ita/concept-platform-tcb.html#platform-tcb-custom-policy-examples